### PR TITLE
Adding domain variable in config system dns section

### DIFF
--- a/fortios/resource_system_setting_dns.go
+++ b/fortios/resource_system_setting_dns.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	forticlient "github.com/fgtdev/fortios-sdk-go/sdkcore"
+	"github.com/fgtdev/fortios-sdk-go/sdkcore"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 

--- a/fortios/resource_system_setting_dns_test.go
+++ b/fortios/resource_system_setting_dns_test.go
@@ -20,6 +20,7 @@ func TestAccFortiOSSystemSettingDNS_basic(t *testing.T) {
 					testAccCheckFortiOSSystemSettingDNSExists("fortios_system_setting_dns.test1"),
 					resource.TestCheckResourceAttr("fortios_system_setting_dns.test1", "primary", "208.91.112.53"),
 					resource.TestCheckResourceAttr("fortios_system_setting_dns.test1", "secondary", "208.91.112.22"),
+					resource.TestCheckResourceAttr("fortios_system_setting_dns.test1", "domain", "abc.example.com"),
 				),
 			},
 		},
@@ -81,5 +82,6 @@ const testAccFortiOSSystemSettingDNSConfig = `
 resource "fortios_system_setting_dns" "test1" { 
 	primary = "208.91.112.53"
 	secondary = "208.91.112.22"
+	domain = "abc.example.com"
 }
 `

--- a/vendor/github.com/fgtdev/fortios-sdk-go/sdkcore/system_setting_dns.go
+++ b/vendor/github.com/fgtdev/fortios-sdk-go/sdkcore/system_setting_dns.go
@@ -3,15 +3,35 @@ package forticlient
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
-	"fmt"
 )
+
+//DomainMultValue Section
+type DomainMultValue struct {
+	Domain string `json:"domain"`
+}
+
+//DomainsMultValues Sections
+type DomainsMultValues []DomainMultValue
+
+// ExpandDomain extracts Domain value from result and put them into a string array,
+// and return the string array
+func ExpandDomain(members []DomainMultValue) []string {
+	vs := make([]string, 0, len(members))
+	for _, v := range members {
+		c := v.Domain
+		vs = append(vs, c)
+	}
+	return vs
+}
 
 // JSONSystemSettingDNS contains the parameters for Create and Update API function
 type JSONSystemSettingDNS struct {
-	Primary   string `json:"primary"`
-	Secondary string `json:"secondary"`
+	Primary   string            `json:"primary"`
+	Secondary string            `json:"secondary"`
+	Domain    DomainsMultValues `json:"domain"`
 }
 
 // JSONCreateSystemSettingDNSOutput contains the output results for Create API function
@@ -265,6 +285,20 @@ func (c *FortiSDKClient) ReadSystemSettingDNS(mkey string) (output *JSONSystemSe
 		}
 		if mapTmp["secondary"] != nil {
 			output.Secondary = mapTmp["secondary"].(string)
+		}
+		if mapTmp["domain"] != nil {
+			member := mapTmp["domain"].([]interface{})
+
+			var members []DomainMultValue
+			for _, v := range member {
+				c := v.(map[string]interface{})
+
+				members = append(members,
+					DomainMultValue{
+						Domain: c["domain"].(string),
+					})
+			}
+			output.Domain = members
 		}
 
 	} else {


### PR DESCRIPTION
To support domain variable in config system dns section

resource "fortios_system_setting_dns" "dns" {
  primary   = "172.31.10.2"
  secondary = "172.31.10.3"
  domain    = ["xyz.abc.net"]
}