### PR TITLE
Add support for DHCP

### DIFF
--- a/fortios/provider.go
+++ b/fortios/provider.go
@@ -46,6 +46,8 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"fortios_networking_route_static":         resourceNetworkingRouteStatic(),
+			"fortios_networking_interface_dhcp":       resourceNetworkingInterfaceDHCP(),
+			"fortios_networking_interface_dhcp_ipres": resourceNetworkingInterfaceDHCPIpRes(),
 			"fortios_networking_interface_port":       resourceNetworkingInterfacePort(),
 			"fortios_system_admin_profiles":           resourceSystemAdminProfiles(),
 			"fortios_system_admin_administrator":      resourceSystemAdminAdministrator(),

--- a/fortios/resource_networking_interface_dhcp.go
+++ b/fortios/resource_networking_interface_dhcp.go
@@ -1,0 +1,200 @@
+package fortios
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	forticlient "github.com/fgtdev/fortios-sdk-go/sdkcore"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceNetworkingInterfaceDHCP() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkingInterfaceDHCPCreate,
+		Read:   resourceNetworkingInterfaceDHCPRead,
+		Update: resourceNetworkingInterfaceDHCPUpdate,
+		Delete: resourceNetworkingInterfaceDHCPDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vdom": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "root",
+			},
+			"default_gw": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "enable",
+			},
+			"netmask": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_range": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"lease_time": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  604800,
+			},
+			// default == Same as System DNS, local == Same as interface, specify == assign dns servers
+			"dns_service": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "default",
+			},
+			"dns_server_1": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0.0.0.0",
+			},
+			"dns_server_2": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0.0.0.0",
+			},
+			"dns_server_3": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0.0.0.0",
+			},
+		},
+	}
+}
+
+func resourceNetworkingInterfaceDHCPCreate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	var ipRange []forticlient.JSONNetworkingInterfaceDHCPIPRange
+	ipr := forticlient.JSONNetworkingInterfaceDHCPIPRange{
+		StartIP: strings.Split(d.Get("ip_range").(string), "-")[0],
+		EndIP:   strings.Split(d.Get("ip_range").(string), "-")[1],
+	}
+	ipRange = append(ipRange, ipr)
+
+	i := &forticlient.JSONNetworkingInterfaceDHCP{
+		Interface:      d.Get("interface").(string),
+		Vdom:           d.Get("vdom").(string),
+		DefaultGateway: d.Get("default_gw").(string),
+		Netmask:        d.Get("netmask").(string),
+		IPRange:        ipRange,
+		DNSService:     d.Get("dns_service").(string),
+		DNSServer1:     d.Get("dns_server_1").(string),
+		DNSServer2:     d.Get("dns_server_2").(string),
+		DNSServer3:     d.Get("dns_server_3").(string),
+		LeaseTime:      d.Get("lease_time").(int),
+	}
+
+	//Call process by sdk
+	o, err := c.CreateNetworkingInterfaceDHCP(i)
+	if err != nil {
+		return fmt.Errorf("error creating Networking Interface DHCP Server: %s", err)
+	}
+
+	//Set index for d
+	log.Printf("FOS-id is %v\n", o.Mkey)
+	d.SetId(o.Mkey)
+
+	return resourceNetworkingInterfaceDHCPRead(d, m)
+}
+
+func resourceNetworkingInterfaceDHCPUpdate(d *schema.ResourceData, m interface{}) error {
+	mkey := d.Id()
+
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	var ipRange []forticlient.JSONNetworkingInterfaceDHCPIPRange
+	ipr := forticlient.JSONNetworkingInterfaceDHCPIPRange{
+		StartIP: strings.Split(d.Get("ip_range").(string), "-")[0],
+		EndIP:   strings.Split(d.Get("ip_range").(string), "-")[1],
+	}
+	ipRange = append(ipRange, ipr)
+
+	i := &forticlient.JSONNetworkingInterfaceDHCP{
+		Interface:      d.Get("interface").(string),
+		Vdom:           d.Get("vdom").(string),
+		DefaultGateway: d.Get("default_gw").(string),
+		Netmask:        d.Get("netmask").(string),
+		IPRange:        ipRange,
+		DNSService:     d.Get("dns_service").(string),
+		DNSServer1:     d.Get("dns_server_1").(string),
+		DNSServer2:     d.Get("dns_server_2").(string),
+		DNSServer3:     d.Get("dns_server_3").(string),
+		LeaseTime:      d.Get("lease_time").(int),
+	}
+
+	//Call process by sdk
+	_, err := c.UpdateNetworkingInterfaceDHCP(i, mkey)
+	if err != nil {
+		return fmt.Errorf("error updating Networking Interface DHCP Server: %s", err)
+	}
+
+	return resourceNetworkingInterfaceDHCPRead(d, m)
+}
+
+func resourceNetworkingInterfaceDHCPDelete(d *schema.ResourceData, m interface{}) error {
+	mkey := d.Id()
+
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	//Call process by sdk
+	err := c.DeleteNetworkingInterfaceDHCP(mkey)
+	if err != nil {
+		return fmt.Errorf("error deleting Networking Interface DHCP Server: %s", err)
+	}
+
+	//Set index for d
+	d.SetId("")
+
+	return nil
+}
+
+func resourceNetworkingInterfaceDHCPRead(d *schema.ResourceData, m interface{}) error {
+	mkey := d.Id()
+
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	//Call process by sdk
+	o, err := c.ReadNetworkingInterfaceDHCP(mkey)
+	if err != nil {
+		return fmt.Errorf("error reading Networking Interface DHCP Server: %s", err)
+	}
+
+	if o == nil {
+		log.Printf("[WARN] resource (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	//Refresh property
+
+	d.Set("interface", o.Interface)
+	d.Set("vdom", o.Vdom)
+	d.Set("default_gw", o.DefaultGateway)
+	d.Set("netmask", o.Netmask)
+	d.Set("ip_range", o.IPRange[0].StartIP+"-"+o.IPRange[0].EndIP)
+	d.Set("dns_service", o.DNSService)
+	d.Set("dns_server_1", o.DNSServer1)
+	d.Set("dns_server_2", o.DNSServer2)
+	d.Set("dns_server_3", o.DNSServer3)
+	d.Set("status", o.Status)
+	d.Set("lease_time", o.LeaseTime)
+
+	return nil
+}

--- a/fortios/resource_networking_interface_dhcp_test.go
+++ b/fortios/resource_networking_interface_dhcp_test.go
@@ -1,0 +1,171 @@
+package fortios
+
+import (
+	"fmt"
+	forticlient "github.com/fgtdev/fortios-sdk-go/sdkcore"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccFortiOSNetworkingInterfaceDHCP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFortiOSNetworkingInterfaceDHCPDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Setup Interface to test with, Not working
+				Config:  testAccFortiOSNetworkingInterfacePortConfigDHCP,
+				Destroy: false,
+				//Check: resource.ComposeTestCheckFunc(
+				//	testAccCheckFortiOSNetworkingInterfacePortExists("fortios_networking_interface_port.test99"),
+				//	resource.TestCheckResourceAttr("fortios_networking_interface_port.test99", "name", "TestIntf99"),
+				//),
+			},
+
+			{
+				Config: testAccFortiOSNetworkingInterfaceDHCPConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFortiOSNetworkingInterfaceDHCPExists("fortios_networking_interface_dhcp.test1"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "interface", "TestIntf"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "ip_range", "10.10.10.10-10.10.10.100"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "default_gw", "10.10.10.1"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "netmask", "255.255.255.0"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "vdom", "root"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "dns_service", "default"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "dns_server_1", "0.0.0.0"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "dns_server_2", "0.0.0.0"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp.test1", "dns_server_3", "0.0.0.0"),
+				),
+			},
+		},
+	})
+}
+
+// TODO Network interface needs to be created for test case to work.
+
+const testAccFortiOSNetworkingInterfaceDHCPConfig = `
+resource "fortios_networking_interface_dhcp" "test1" {
+	interface = "TestIntf"
+	ip_range = "10.10.10.10-10.10.10.100"
+	default_gw = "10.10.10.1"
+	netmask = "255.255.255.0"
+	vdom = "root"
+	dns_service = "default"
+	dns_server_1 = "0.0.0.0"
+	dns_server_2 = "0.0.0.0"
+	dns_server_3 = "0.0.0.0"
+}
+`
+const testAccFortiOSNetworkingInterfacePortConfigDHCP = `
+resource "fortios_networking_interface_port" "test99" {
+	name = "TestIntf99"
+	allowaccess = "ping"
+	ip = "1.1.1.1 255.255.255.0"
+	description = "Terraform Test"
+	vdom = "root"
+	role = "lan"
+	mode = "static"
+	interface = "port1"
+	vlanid = "99"
+	distance = "5"
+	defaultgw = "enable"
+	type = "vlan"
+}
+`
+
+func testAccCheckFortiOSNetworkingInterfaceDHCPExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found Networking Interface DHCP resource named: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Networking Interface DHCP Server is set")
+		}
+
+		c := testAccProvider.Meta().(*FortiClient).Client
+
+		i := rs.Primary.ID
+		o, err := c.ReadNetworkingInterfaceDHCP(i)
+
+		if err != nil {
+			return fmt.Errorf("Error reading Networking Interface DHCP: %s", err)
+		}
+
+		if o == nil {
+			return fmt.Errorf("Error creating Networking Interface DHCP: %s", n)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckFortiOSNetworkingInterfaceDHCPDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*FortiClient).Client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "fortios_networking_interface_dhcp" {
+			continue
+		}
+
+		i := rs.Primary.ID
+		o, err := c.ReadNetworkingInterfaceDHCP(i)
+
+		if err == nil {
+			if o != nil {
+				return fmt.Errorf("Error Networking Interface DHCP %s still exists", rs.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccCheckFortiOSNetworkingInterfaceDHCPPreStep() (mkey string, err error) {
+	c := testAccProvider.Meta().(*FortiClient).Client
+
+	in := &forticlient.JSONNetworkingInterfacePort{
+		Ipf:                  "93.133.133.110 255.255.255.0",
+		Alias:                "physicalport8",
+		Status:               "up",
+		DeviceIdentification: "enable",
+		TCPMss:               "3232",
+		Speed:                "auto",
+		MtuOverride:          "enable",
+		Mtu:                  "1500",
+		Role:                 "lan",
+		Allowaccess:          "ping https",
+		Mode:                 "static",
+		DNSServerOverride:    "enable",
+		Defaultgw:            "enable",
+		Distance:             "5",
+		Description:          "Terraform Test",
+		Type:                 "physical",
+		Name:                 "port8",
+	}
+
+	o, err := c.CreateNetworkingInterfacePort(in)
+	if err != nil {
+		fmt.Println(err.Error())
+		return "", err
+	}
+
+	return o.Mkey, nil
+}
+
+func testAccCheckFortiOSNetworkingInterfaceDHCPPostStep(mkey string) (err error) {
+	c := testAccProvider.Meta().(*FortiClient).Client
+	err = c.DeleteNetworkingInterfacePort(mkey)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/fortios/resource_networking_interface_dhcpres.go
+++ b/fortios/resource_networking_interface_dhcpres.go
@@ -1,0 +1,161 @@
+package fortios
+
+import (
+	"fmt"
+	forticlient "github.com/fgtdev/fortios-sdk-go/sdkcore"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func resourceNetworkingInterfaceDHCPIpRes() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkingInterfaceDHCPIpResCreate,
+		Read:   resourceNetworkingInterfaceDHCPIpResRead,
+		Update: resourceNetworkingInterfaceDHCPIpResUpdate,
+		Delete: resourceNetworkingInterfaceDHCPiPResDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vdom": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "root",
+			},
+			"ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "enable",
+			},
+			"mac": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Object Managed by Terraform",
+			},
+		},
+	}
+}
+
+func resourceNetworkingInterfaceDHCPIpResCreate(d *schema.ResourceData, m interface{}) error {
+	logPrefix := "resourceNetworkingInterfaceDHCPIpResCreate"
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	skey, err := c.NetworkingInterfaceDHCPSrvByName(d.Get("interface").(string))
+	if err != nil {
+		return fmt.Errorf("error retrieving DHCP Server from interface: %s", err)
+	}
+
+	i := &forticlient.JSONNetworkingInterfaceDHCPIpRes{
+		IP:          d.Get("ip").(string),
+		Mac:         d.Get("mac").(string),
+		Description: d.Get("description").(string),
+		Vdom:        d.Get("vdom").(string),
+	}
+
+	//Call process by sdk
+	o, err := c.CreateNetworkInterfaceDHCPIpPRes(i, skey)
+	if err != nil {
+		return fmt.Errorf("error creating DHCP IP Reservation: %s", err)
+	}
+
+	//Set index for d
+	log.Printf(logPrefix+"FOS-id is %v\n", o.Mkey)
+	d.SetId(o.Mkey)
+
+	return resourceNetworkingInterfaceDHCPIpResRead(d, m)
+}
+
+func resourceNetworkingInterfaceDHCPIpResUpdate(d *schema.ResourceData, m interface{}) error {
+	logPrefix := "resourceNetworkingInterfaceDHCPIpResUpdate"
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	skey, err := c.NetworkingInterfaceDHCPSrvByName(d.Get("interface").(string))
+	if err != nil {
+		return fmt.Errorf("error retrieving DHCP Server from interface: %s", err)
+	}
+	mkey := d.Id()
+
+	i := &forticlient.JSONNetworkingInterfaceDHCPIpRes{
+		IP:          d.Get("ip").(string),
+		Mac:         d.Get("mac").(string),
+		Description: d.Get("description").(string),
+		Vdom:        d.Get("vdom").(string),
+	}
+
+	//Call process by sdk
+	o, err := c.UpdateNetworkInterfaceDHCPIpPRes(i, skey, mkey)
+	if err != nil {
+		return fmt.Errorf("error creating DHCP IP Reservation: %s", err)
+	}
+
+	//Set index for d
+	log.Printf(logPrefix+"FOS-id is %v\n", o.Mkey)
+	d.SetId(o.Mkey)
+
+	return resourceNetworkingInterfaceDHCPIpResRead(d, m)
+}
+
+func resourceNetworkingInterfaceDHCPiPResDelete(d *schema.ResourceData, m interface{}) error {
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	skey, err := c.NetworkingInterfaceDHCPSrvByName(d.Get("interface").(string))
+	if err != nil {
+		return fmt.Errorf("error retrieving DHCP Server from interface: %s", err)
+	}
+	mkey := d.Id()
+
+	//Call process by sdk
+	_, err = c.DeleteNetworkingInterfaceDHCPIpRes(skey, mkey)
+	if err != nil {
+		return fmt.Errorf("error deleting DHCPm IP Reservation: %s", err)
+	}
+
+	//Set index for d
+	d.SetId("")
+
+	return nil
+}
+
+func resourceNetworkingInterfaceDHCPIpResRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	skey, err := c.NetworkingInterfaceDHCPSrvByName(d.Get("interface").(string))
+	if err != nil {
+		return fmt.Errorf("error retrieving DHCP Server from interface: %s", err)
+	}
+	mkey := d.Id()
+
+	//Call process by sdk
+	o, err := c.ReadNetworkingInterfaceDHCPIpRes(skey, mkey)
+	if err != nil {
+		return fmt.Errorf("error reading DHCP IP Reservation: %s", err)
+	}
+
+	if o == nil {
+		log.Printf("[WARN] resource (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	//Refresh property
+	d.Set("ip", o.IP)
+	d.Set("mac", o.Mac)
+	d.Set("description", o.Description)
+	d.Set("vdom", o.Vdom)
+
+	return nil
+}

--- a/fortios/resource_networking_interface_dhcpres_test.go
+++ b/fortios/resource_networking_interface_dhcpres_test.go
@@ -1,0 +1,73 @@
+package fortios
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccFortiOSNetworkingInterfaceDHCPIpRes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFortiOSNetworkingInterfaceDHCPRes,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFortiOSNetworkingInterfaceDHCPResExists("fortios_networking_interface_dhcp_ipres.test1"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp_ipres.test1", "interface", "TestIntf"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp_ipres.test1", "ip", "10.10.10.12"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp_ipres.test1", "mac", "82:05:27:89:50:01"),
+					resource.TestCheckResourceAttr("fortios_networking_interface_dhcp_ipres.test1", "description", "Terraform Test"),
+				),
+			},
+		},
+	})
+}
+
+// TODO Network interface & associated DHCP config needs to be created for test case to work.
+const testAccFortiOSNetworkingInterfaceDHCPRes = `
+resource "fortios_networking_interface_dhcp_ipres" "test1" {
+	interface = "TestIntf"
+	ip = "10.10.10.12"
+	mac = "82:05:27:89:50:01"
+	description = "Terraform Test"
+    vdom = "root"
+}
+`
+
+func testAccCheckFortiOSNetworkingInterfaceDHCPResExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found DHCP Reservation resource named: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DHCP Reservation is set")
+		}
+
+		c := testAccProvider.Meta().(*FortiClient).Client
+		i := rs.Primary.ID
+		attr := rs.Primary.Attributes
+
+		skey, err := c.NetworkingInterfaceDHCPSrvByName(attr["interface"])
+		if err != nil {
+			return fmt.Errorf("error retrieving DHCP Server from interface: %s", err)
+		}
+
+		o, err := c.ReadNetworkingInterfaceDHCPIpRes(skey, i)
+
+		if err != nil {
+			return fmt.Errorf("Error reading DHCP IP Reservation: %s", err)
+		}
+
+		if o == nil {
+			return fmt.Errorf("Error creating DHCP IP Reservation: %s", n)
+		}
+
+		return nil
+	}
+}

--- a/website/docs/r/fortios_networking_interface_dhcp.html.markdown
+++ b/website/docs/r/fortios_networking_interface_dhcp.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "fortios"
+page_title: "FortiOS: fortios_networking_interface_dhcp"
+sidebar_current: "docs-fortios-resource-networking-interface-dhcp"
+description: |-
+  Provides a resource to configure interface DHCP settings of FortiOS.
+---
+
+# fortios_networking_interface_dhcp
+Provides a resource to configure interface DHCP settings of FortiOS.
+
+## Example Usage for vlan Interface
+```hcl
+
+provider "fortios" {
+  hostname = "54.226.179.231"
+  token    = "jn3t3Nw7qckQzt955Htkfj5hwQ6jdb"
+  vdom     = "root"
+}
+
+
+resource "fortios_networking_interface_dhcp" "dhcp_server" {
+  interface    = "TestIntf"
+  ip_range     = "10.10.10.10-10.10.10.100"
+  default_gw   = "10.10.10.1"
+  netmask      = "255.255.255.0"
+  vdom         = "root"
+  dns_service  = "default"
+  dns_server_1 = "0.0.0.0"
+  dns_server_2 = "0.0.0.0"
+  dns_server_3 = "0.0.0.0"
+  lease_time   = 500
+}
+
+```
+
+## Argument Reference
+The following arguments are supported:
+
+* `interface` - (Required) Interface name to attache dhcp service.
+* `ip_range` - (Required) IP Range to hand out from dhcp service. Syntax X.X.X.X-Y.Y.Y.Y where X is start.
+* `netmask` - (Required) Netmask set on the IPs handed out from dhcp service.
+* `default_gw` - Default gateway to hand out, default would be interface assigned gw.
+* `dns_service` - DNS Service - Options default == Same as System DNS, local == Same as interface, specify == Assign DNS servers
+* `dns_server_1` - DNS Server number 1 if dns_service = "specify"
+* `dns_server_2` - DNS Server number 2 if dns_service = "specify"
+* `dns_server_3` - DNS Server number 3 if dns_service = "specify"
+* `lease_time` - IP Lease time, default value 604800
+
+
+## Attributes Reference
+The following attributes are exported:
+
+* `id` - The Name of the interface.
+* `status` - Service status, enable or disable
+* `vdom` - Servic is in this virtual domain (VDOM).

--- a/website/docs/r/fortios_networking_interface_dhcpres.html.markdown
+++ b/website/docs/r/fortios_networking_interface_dhcpres.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "fortios"
+page_title: "FortiOS: fortios_networking_interface_dhcp_ipres"
+sidebar_current: "docs-fortios-resource-networking-interface-dhcp-ipres"
+description: |-
+  Provides a resource to configure interface DHCP IP Reservation settings of FortiOS.
+---
+
+# fortios_networking_interface_dhcp_ipres
+Provides a resource to configure interface DHCP IP Reservation settings of FortiOS.
+
+## Example Usage
+```hcl
+
+provider "fortios" {
+  hostname = "54.226.179.231"
+  token    = "jn3t3Nw7qckQzt955Htkfj5hwQ6jdb"
+  vdom     = "root"
+}
+
+
+resource "fortios_networking_interface_dhcp" "dhcp_server" {
+  interface    = "TestIntf"
+  ip_range     = "10.10.10.10-10.10.10.100"
+  default_gw   = "10.10.10.1"
+  netmask      = "255.255.255.0"
+  vdom         = "root"
+  dns_service  = "default"
+  dns_server_1 = "0.0.0.0"
+  dns_server_2 = "0.0.0.0"
+  dns_server_3 = "0.0.0.0"
+  lease_time   = 500
+}
+
+resource "fortios_networking_interface_dhcp_ipres" "reserv_1" {
+  interface   = fortios_networking_interface_dhcp.dhcp_server.interface
+  ip          = "10.10.10.12"
+  mac         = "82:05:27:89:50:01"
+  description = "Terraform Provisioned Reservation"
+}
+
+```
+
+## Argument Reference
+The following arguments are supported:
+
+* `interface` - (Required) Interface name where dhcp service is running.
+* `ip` - (Required) IP to hand out from dhcp service. 
+* `mac` - (Required) MAC adrress for the reservation.
+* `description` - Optional Description
+
+
+## Attributes Reference
+The following attributes are exported:
+
+* `id` - The Name of the interface.

--- a/website/fortios.erb
+++ b/website/fortios.erb
@@ -30,6 +30,14 @@
                             <a href="/docs/providers/fortios/r/fortios_networking_interface_port.html">fortios_networking_interface_port</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-fortios-resource-networking-interface-dhcp") %>>
+                            <a href="/docs/providers/fortios/r/fortios_networking_interface_dhcp.html">fortios_networking_interface_dhcp</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-fortios-resource-networking-interface-dhcp-ipres") %>>
+                            <a href="/docs/providers/fortios/r/fortios_networking_interface_dhcpres.html">fortios_networking_interface_dhcp_ipres</a>
+                         </li>
+
                         <li<%= sidebar_current("docs-fortios-resource-networking-route-static") %>>
                             <a href="/docs/providers/fortios/r/fortios_networking_route_static.html">fortios_networking_route_static</a>
                         </li>


### PR DESCRIPTION
Adds support for DHCP configuration on interfaces. Depends on PR#12 for fgtdev/fortios-sdk-go