### PR TITLE
Add ForceNew to vlanid attribute

### DIFF
--- a/fortios/resource_system_interface.go
+++ b/fortios/resource_system_interface.go
@@ -672,6 +672,7 @@ func resourceSystemInterface() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 4094),
 				Optional:     true,
 				Computed:     true,
+				ForceNew:     true,
 			},
 			"forward_domain": &schema.Schema{
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Changing the vlanid once set is not possible. Add ForceNew to ensure new resource is created upon change.