### PR TITLE
corrected additional-path-select and additional-path-select6

### DIFF
--- a/fortios/resource_router_bgp.go
+++ b/fortios/resource_router_bgp.go
@@ -280,13 +280,13 @@ func resourceRouterBgp() *schema.Resource {
 			},
 			"additional_path_select": &schema.Schema{
 				Type:         schema.TypeInt,
-				ValidateFunc: validation.IntBetween(2, 3),
+				ValidateFunc: validation.IntBetween(2, 255),
 				Optional:     true,
 				Computed:     true,
 			},
 			"additional_path_select6": &schema.Schema{
 				Type:         schema.TypeInt,
-				ValidateFunc: validation.IntBetween(2, 3),
+				ValidateFunc: validation.IntBetween(2, 255),
 				Optional:     true,
 				Computed:     true,
 			},


### PR DESCRIPTION
additional-path-select  and additional-path-select6 can use integer values from 2-255. The tooltip output is below.

'''Enter an integer value from <2> to <255> (default = <2>)Enter an integer value from <2> to <255> (default = <2>)'''

the current provider allows only 2-3

I used the change in the PR with a locally built provided and it worked as expected..