### PR TITLE
Fix sorting of Service Group members #217

### DIFF
--- a/fortios/config.go
+++ b/fortios/config.go
@@ -73,7 +73,7 @@ func sortStringwithNumber(v string) string {
 	return v[:i] + string(b64)
 }
 
-func dynamic_sort_subtable(result []map[string]interface{}, fieldname string, d *schema.ResourceData) {
+func dynamic_sort_subtable_natural(result []map[string]interface{}, fieldname string, d *schema.ResourceData) {
 	if v, ok := d.GetOk("dynamic_sort_subtable"); ok {
 		if v.(string) == "true" {
 			sort.Slice(result, func(i, j int) bool {
@@ -81,6 +81,19 @@ func dynamic_sort_subtable(result []map[string]interface{}, fieldname string, d 
 				v2 := fmt.Sprintf("%v", result[j][fieldname])
 
 				return sortStringwithNumber(v1) < sortStringwithNumber(v2)
+			})
+		}
+	}
+}
+
+func dynamic_sort_subtable(result []map[string]interface{}, fieldname string, d *schema.ResourceData) {
+	if v, ok := d.GetOk("dynamic_sort_subtable"); ok {
+		if v.(string) == "true" {
+			sort.Slice(result, func(i, j int) bool {
+				v1 := fmt.Sprintf("%v", result[i][fieldname])
+				v2 := fmt.Sprintf("%v", result[j][fieldname])
+
+				return v1 < v2
 			})
 		}
 	}

--- a/fortios/resource_antivirus_profile.go
+++ b/fortios/resource_antivirus_profile.go
@@ -2438,7 +2438,7 @@ func flattenAntivirusProfileExternalBlocklist(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_application_group.go
+++ b/fortios/resource_application_group.go
@@ -288,7 +288,7 @@ func flattenApplicationGroupApplication(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -326,7 +326,7 @@ func flattenApplicationGroupCategory(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -364,7 +364,7 @@ func flattenApplicationGroupRisk(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "level", d)
+	dynamic_sort_subtable_natural(result, "level", d)
 	return result
 }
 

--- a/fortios/resource_application_list.go
+++ b/fortios/resource_application_list.go
@@ -738,7 +738,7 @@ func flattenApplicationListEntries(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1169,7 +1169,7 @@ func flattenApplicationListDefaultNetworkServices(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_application_name.go
+++ b/fortios/resource_application_name.go
@@ -342,7 +342,7 @@ func flattenApplicationNameParameters(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -396,7 +396,7 @@ func flattenApplicationNameMetadata(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_authentication_rule.go
+++ b/fortios/resource_authentication_rule.go
@@ -331,7 +331,7 @@ func flattenAuthenticationRuleSrcintf(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -369,7 +369,7 @@ func flattenAuthenticationRuleSrcaddr(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -407,7 +407,7 @@ func flattenAuthenticationRuleDstaddr(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -445,7 +445,7 @@ func flattenAuthenticationRuleSrcaddr6(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -483,7 +483,7 @@ func flattenAuthenticationRuleDstaddr6(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_authentication_scheme.go
+++ b/fortios/resource_authentication_scheme.go
@@ -320,7 +320,7 @@ func flattenAuthenticationSchemeUserDatabase(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_authentication_setting.go
+++ b/fortios/resource_authentication_setting.go
@@ -325,7 +325,7 @@ func flattenAuthenticationSettingUserCertCa(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -363,7 +363,7 @@ func flattenAuthenticationSettingDevRange(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_cifs_profile.go
+++ b/fortios/resource_cifs_profile.go
@@ -462,7 +462,7 @@ func flattenCifsProfileServerKeytab(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "principal", d)
+	dynamic_sort_subtable_natural(result, "principal", d)
 	return result
 }
 

--- a/fortios/resource_dlp_filepattern.go
+++ b/fortios/resource_dlp_filepattern.go
@@ -258,7 +258,7 @@ func flattenDlpFilepatternEntries(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "pattern", d)
+	dynamic_sort_subtable_natural(result, "pattern", d)
 	return result
 }
 

--- a/fortios/resource_dlp_sensor.go
+++ b/fortios/resource_dlp_sensor.go
@@ -468,7 +468,7 @@ func flattenDlpSensorFilter(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_dnsfilter_domainfilter.go
+++ b/fortios/resource_dnsfilter_domainfilter.go
@@ -280,7 +280,7 @@ func flattenDnsfilterDomainFilterEntries(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_dnsfilter_profile.go
+++ b/fortios/resource_dnsfilter_profile.go
@@ -540,7 +540,7 @@ func flattenDnsfilterProfileExternalIpBlocklist(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -626,7 +626,7 @@ func flattenDnsfilterProfileDnsTranslation(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_dpdk_global.go
+++ b/fortios/resource_dpdk_global.go
@@ -218,7 +218,7 @@ func flattenDpdkGlobalInterface(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_emailfilter_blockallowlist.go
+++ b/fortios/resource_emailfilter_blockallowlist.go
@@ -326,7 +326,7 @@ func flattenEmailfilterBlockAllowListEntries(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_emailfilter_bwl.go
+++ b/fortios/resource_emailfilter_bwl.go
@@ -326,7 +326,7 @@ func flattenEmailfilterBwlEntries(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_emailfilter_bword.go
+++ b/fortios/resource_emailfilter_bword.go
@@ -316,7 +316,7 @@ func flattenEmailfilterBwordEntries(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_emailfilter_dnsbl.go
+++ b/fortios/resource_emailfilter_dnsbl.go
@@ -271,7 +271,7 @@ func flattenEmailfilterDnsblEntries(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_emailfilter_iptrust.go
+++ b/fortios/resource_emailfilter_iptrust.go
@@ -281,7 +281,7 @@ func flattenEmailfilterIptrustEntries(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_emailfilter_mheader.go
+++ b/fortios/resource_emailfilter_mheader.go
@@ -294,7 +294,7 @@ func flattenEmailfilterMheaderEntries(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_endpointcontrol_profile.go
+++ b/fortios/resource_endpointcontrol_profile.go
@@ -1840,7 +1840,7 @@ func flattenEndpointControlProfileSrcAddr(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1878,7 +1878,7 @@ func flattenEndpointControlProfileDeviceGroups(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1916,7 +1916,7 @@ func flattenEndpointControlProfileUsers(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1954,7 +1954,7 @@ func flattenEndpointControlProfileUserGroups(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1992,7 +1992,7 @@ func flattenEndpointControlProfileOnNetAddr(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_filefilter_profile.go
+++ b/fortios/resource_filefilter_profile.go
@@ -350,7 +350,7 @@ func flattenFileFilterProfileRules(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_DoSpolicy.go
+++ b/fortios/resource_firewall_DoSpolicy.go
@@ -339,7 +339,7 @@ func flattenFirewallDosPolicySrcaddr(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -377,7 +377,7 @@ func flattenFirewallDosPolicyDstaddr(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -415,7 +415,7 @@ func flattenFirewallDosPolicyService(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -501,7 +501,7 @@ func flattenFirewallDosPolicyAnomaly(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_DoSpolicy6.go
+++ b/fortios/resource_firewall_DoSpolicy6.go
@@ -339,7 +339,7 @@ func flattenFirewallDosPolicy6Srcaddr(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -377,7 +377,7 @@ func flattenFirewallDosPolicy6Dstaddr(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -415,7 +415,7 @@ func flattenFirewallDosPolicy6Service(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -501,7 +501,7 @@ func flattenFirewallDosPolicy6Anomaly(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_accessproxy.go
+++ b/fortios/resource_firewall_accessproxy.go
@@ -905,7 +905,7 @@ func flattenFirewallAccessProxyApiGateway(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1442,7 +1442,7 @@ func flattenFirewallAccessProxyApiGateway6(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_accessproxy6.go
+++ b/fortios/resource_firewall_accessproxy6.go
@@ -905,7 +905,7 @@ func flattenFirewallAccessProxy6ApiGateway(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1442,7 +1442,7 @@ func flattenFirewallAccessProxy6ApiGateway6(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_accessproxysshclientcert.go
+++ b/fortios/resource_firewall_accessproxysshclientcert.go
@@ -313,7 +313,7 @@ func flattenFirewallAccessProxySshClientCertCertExtension(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_address.go
+++ b/fortios/resource_firewall_address.go
@@ -505,7 +505,7 @@ func flattenFirewallAddressMacaddr(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "macaddr", d)
+	dynamic_sort_subtable_natural(result, "macaddr", d)
 	return result
 }
 
@@ -590,7 +590,7 @@ func flattenFirewallAddressFssoGroup(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -704,7 +704,7 @@ func flattenFirewallAddressList(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -754,7 +754,7 @@ func flattenFirewallAddressTagging(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_address6.go
+++ b/fortios/resource_firewall_address6.go
@@ -401,7 +401,7 @@ func flattenFirewallAddress6Macaddr(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "macaddr", d)
+	dynamic_sort_subtable_natural(result, "macaddr", d)
 	return result
 }
 
@@ -487,7 +487,7 @@ func flattenFirewallAddress6List(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -537,7 +537,7 @@ func flattenFirewallAddress6Tagging(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -636,7 +636,7 @@ func flattenFirewallAddress6SubnetSegment(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_address6template.go
+++ b/fortios/resource_firewall_address6template.go
@@ -300,7 +300,7 @@ func flattenFirewallAddress6TemplateSubnetSegment(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_addrgrp.go
+++ b/fortios/resource_firewall_addrgrp.go
@@ -324,7 +324,7 @@ func flattenFirewallAddrgrpMember(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -370,7 +370,7 @@ func flattenFirewallAddrgrpExcludeMember(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -428,7 +428,7 @@ func flattenFirewallAddrgrpTagging(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_addrgrp6.go
+++ b/fortios/resource_firewall_addrgrp6.go
@@ -295,7 +295,7 @@ func flattenFirewallAddrgrp6Member(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -345,7 +345,7 @@ func flattenFirewallAddrgrp6Tagging(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_authportal.go
+++ b/fortios/resource_firewall_authportal.go
@@ -195,7 +195,7 @@ func flattenFirewallAuthPortalGroups(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_centralsnatmap.go
+++ b/fortios/resource_firewall_centralsnatmap.go
@@ -377,7 +377,7 @@ func flattenFirewallCentralSnatMapOrigAddr(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -415,7 +415,7 @@ func flattenFirewallCentralSnatMapOrigAddr6(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -453,7 +453,7 @@ func flattenFirewallCentralSnatMapSrcintf(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -491,7 +491,7 @@ func flattenFirewallCentralSnatMapDstAddr(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -529,7 +529,7 @@ func flattenFirewallCentralSnatMapDstAddr6(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -567,7 +567,7 @@ func flattenFirewallCentralSnatMapDstintf(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -605,7 +605,7 @@ func flattenFirewallCentralSnatMapNatIppool(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -643,7 +643,7 @@ func flattenFirewallCentralSnatMapNatIppool6(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_country.go
+++ b/fortios/resource_firewall_country.go
@@ -229,7 +229,7 @@ func flattenFirewallCountryRegion(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_decryptedtrafficmirror.go
+++ b/fortios/resource_firewall_decryptedtrafficmirror.go
@@ -246,7 +246,7 @@ func flattenFirewallDecryptedTrafficMirrorInterface(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_identitybasedroute.go
+++ b/fortios/resource_firewall_identitybasedroute.go
@@ -270,7 +270,7 @@ func flattenFirewallIdentityBasedRouteRule(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_interfacepolicy.go
+++ b/fortios/resource_firewall_interfacepolicy.go
@@ -385,7 +385,7 @@ func flattenFirewallInterfacePolicySrcaddr(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -423,7 +423,7 @@ func flattenFirewallInterfacePolicyDstaddr(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -461,7 +461,7 @@ func flattenFirewallInterfacePolicyService(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_interfacepolicy6.go
+++ b/fortios/resource_firewall_interfacepolicy6.go
@@ -385,7 +385,7 @@ func flattenFirewallInterfacePolicy6Srcaddr6(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -423,7 +423,7 @@ func flattenFirewallInterfacePolicy6Dstaddr6(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -461,7 +461,7 @@ func flattenFirewallInterfacePolicy6Service6(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_internetserviceaddition.go
+++ b/fortios/resource_firewall_internetserviceaddition.go
@@ -270,7 +270,7 @@ func flattenFirewallInternetServiceAdditionEntry(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_internetservicecustom.go
+++ b/fortios/resource_firewall_internetservicecustom.go
@@ -300,7 +300,7 @@ func flattenFirewallInternetServiceCustomEntry(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_internetservicecustomgroup.go
+++ b/fortios/resource_firewall_internetservicecustomgroup.go
@@ -228,7 +228,7 @@ func flattenFirewallInternetServiceCustomGroupMember(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_internetservicedefinition.go
+++ b/fortios/resource_firewall_internetservicedefinition.go
@@ -295,7 +295,7 @@ func flattenFirewallInternetServiceDefinitionEntry(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "seq_num", d)
+	dynamic_sort_subtable_natural(result, "seq_num", d)
 	return result
 }
 

--- a/fortios/resource_firewall_internetserviceextension.go
+++ b/fortios/resource_firewall_internetserviceextension.go
@@ -363,7 +363,7 @@ func flattenFirewallInternetServiceExtensionEntry(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -523,7 +523,7 @@ func flattenFirewallInternetServiceExtensionDisableEntry(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_internetservicegroup.go
+++ b/fortios/resource_firewall_internetservicegroup.go
@@ -248,7 +248,7 @@ func flattenFirewallInternetServiceGroupMember(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_localinpolicy.go
+++ b/fortios/resource_firewall_localinpolicy.go
@@ -310,7 +310,7 @@ func flattenFirewallLocalInPolicySrcaddr(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -352,7 +352,7 @@ func flattenFirewallLocalInPolicyDstaddr(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -398,7 +398,7 @@ func flattenFirewallLocalInPolicyService(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_localinpolicy6.go
+++ b/fortios/resource_firewall_localinpolicy6.go
@@ -300,7 +300,7 @@ func flattenFirewallLocalInPolicy6Srcaddr(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -342,7 +342,7 @@ func flattenFirewallLocalInPolicy6Dstaddr(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -388,7 +388,7 @@ func flattenFirewallLocalInPolicy6Service(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_multicastaddress.go
+++ b/fortios/resource_firewall_multicastaddress.go
@@ -330,7 +330,7 @@ func flattenFirewallMulticastAddressTagging(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_multicastaddress6.go
+++ b/fortios/resource_firewall_multicastaddress6.go
@@ -287,7 +287,7 @@ func flattenFirewallMulticastAddress6Tagging(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_multicastpolicy.go
+++ b/fortios/resource_firewall_multicastpolicy.go
@@ -340,7 +340,7 @@ func flattenFirewallMulticastPolicySrcaddr(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -378,7 +378,7 @@ func flattenFirewallMulticastPolicyDstaddr(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_multicastpolicy6.go
+++ b/fortios/resource_firewall_multicastpolicy6.go
@@ -321,7 +321,7 @@ func flattenFirewallMulticastPolicy6Srcaddr(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -359,7 +359,7 @@ func flattenFirewallMulticastPolicy6Dstaddr(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_policy.go
+++ b/fortios/resource_firewall_policy.go
@@ -1360,7 +1360,7 @@ func flattenFirewallPolicySrcintf(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1398,7 +1398,7 @@ func flattenFirewallPolicyDstintf(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1436,7 +1436,7 @@ func flattenFirewallPolicySrcaddr(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1474,7 +1474,7 @@ func flattenFirewallPolicyDstaddr(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1512,7 +1512,7 @@ func flattenFirewallPolicySrcaddr6(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1550,7 +1550,7 @@ func flattenFirewallPolicyDstaddr6(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1592,7 +1592,7 @@ func flattenFirewallPolicyZtnaEmsTag(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1630,7 +1630,7 @@ func flattenFirewallPolicyZtnaGeoTag(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1672,7 +1672,7 @@ func flattenFirewallPolicyInternetServiceName(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1710,7 +1710,7 @@ func flattenFirewallPolicyInternetServiceId(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1748,7 +1748,7 @@ func flattenFirewallPolicyInternetServiceGroup(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1786,7 +1786,7 @@ func flattenFirewallPolicyInternetServiceCustom(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1824,7 +1824,7 @@ func flattenFirewallPolicyInternetServiceCustomGroup(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1866,7 +1866,7 @@ func flattenFirewallPolicyInternetServiceSrcName(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1904,7 +1904,7 @@ func flattenFirewallPolicyInternetServiceSrcId(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1942,7 +1942,7 @@ func flattenFirewallPolicyInternetServiceSrcGroup(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1980,7 +1980,7 @@ func flattenFirewallPolicyInternetServiceSrcCustom(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2018,7 +2018,7 @@ func flattenFirewallPolicyInternetServiceSrcCustomGroup(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2064,7 +2064,7 @@ func flattenFirewallPolicySrcVendorMac(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2106,7 +2106,7 @@ func flattenFirewallPolicyRtpAddr(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2180,7 +2180,7 @@ func flattenFirewallPolicyService(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2418,7 +2418,7 @@ func flattenFirewallPolicyApplication(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2456,7 +2456,7 @@ func flattenFirewallPolicyAppCategory(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2494,7 +2494,7 @@ func flattenFirewallPolicyUrlCategory(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2532,7 +2532,7 @@ func flattenFirewallPolicyAppGroup(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2590,7 +2590,7 @@ func flattenFirewallPolicyPoolname(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2628,7 +2628,7 @@ func flattenFirewallPolicyPoolname6(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2710,7 +2710,7 @@ func flattenFirewallPolicyNtlmEnabledBrowsers(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "user_agent_string", d)
+	dynamic_sort_subtable_natural(result, "user_agent_string", d)
 	return result
 }
 
@@ -2764,7 +2764,7 @@ func flattenFirewallPolicyGroups(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2802,7 +2802,7 @@ func flattenFirewallPolicyUsers(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2840,7 +2840,7 @@ func flattenFirewallPolicyFssoGroups(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2878,7 +2878,7 @@ func flattenFirewallPolicyDevices(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -3007,7 +3007,7 @@ func flattenFirewallPolicyCustomLogFields(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "field_id", d)
+	dynamic_sort_subtable_natural(result, "field_id", d)
 	return result
 }
 
@@ -3085,7 +3085,7 @@ func flattenFirewallPolicySslMirrorIntf(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -3147,7 +3147,7 @@ func flattenFirewallPolicySgt(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_policy.go
+++ b/fortios/resource_firewall_policy.go
@@ -1436,7 +1436,7 @@ func flattenFirewallPolicySrcaddr(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable_natural(result, "name", d)
+	dynamic_sort_subtable(result, "name", d)
 	return result
 }
 
@@ -1474,7 +1474,7 @@ func flattenFirewallPolicyDstaddr(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable_natural(result, "name", d)
+	dynamic_sort_subtable(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_policy46.go
+++ b/fortios/resource_firewall_policy46.go
@@ -377,7 +377,7 @@ func flattenFirewallPolicy46Srcaddr(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -415,7 +415,7 @@ func flattenFirewallPolicy46Dstaddr(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -465,7 +465,7 @@ func flattenFirewallPolicy46Service(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -543,7 +543,7 @@ func flattenFirewallPolicy46Poolname(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_policy6.go
+++ b/fortios/resource_firewall_policy6.go
@@ -831,7 +831,7 @@ func flattenFirewallPolicy6Srcintf(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -869,7 +869,7 @@ func flattenFirewallPolicy6Dstintf(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -907,7 +907,7 @@ func flattenFirewallPolicy6Srcaddr(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -945,7 +945,7 @@ func flattenFirewallPolicy6Dstaddr(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1007,7 +1007,7 @@ func flattenFirewallPolicy6Service(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1189,7 +1189,7 @@ func flattenFirewallPolicy6Application(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1227,7 +1227,7 @@ func flattenFirewallPolicy6AppCategory(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1265,7 +1265,7 @@ func flattenFirewallPolicy6UrlCategory(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1303,7 +1303,7 @@ func flattenFirewallPolicy6AppGroup(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1353,7 +1353,7 @@ func flattenFirewallPolicy6Poolname(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1459,7 +1459,7 @@ func flattenFirewallPolicy6CustomLogFields(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "field_id", d)
+	dynamic_sort_subtable_natural(result, "field_id", d)
 	return result
 }
 
@@ -1513,7 +1513,7 @@ func flattenFirewallPolicy6Groups(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1551,7 +1551,7 @@ func flattenFirewallPolicy6Users(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1589,7 +1589,7 @@ func flattenFirewallPolicy6Devices(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1639,7 +1639,7 @@ func flattenFirewallPolicy6SslMirrorIntf(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1685,7 +1685,7 @@ func flattenFirewallPolicy6FssoGroups(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_policy64.go
+++ b/fortios/resource_firewall_policy64.go
@@ -373,7 +373,7 @@ func flattenFirewallPolicy64Srcaddr(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -411,7 +411,7 @@ func flattenFirewallPolicy64Dstaddr(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -461,7 +461,7 @@ func flattenFirewallPolicy64Service(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -531,7 +531,7 @@ func flattenFirewallPolicy64Poolname(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_proxyaddress.go
+++ b/fortios/resource_firewall_proxyaddress.go
@@ -392,7 +392,7 @@ func flattenFirewallProxyAddressCategory(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -468,7 +468,7 @@ func flattenFirewallProxyAddressHeaderGroup(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -534,7 +534,7 @@ func flattenFirewallProxyAddressTagging(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_proxyaddrgrp.go
+++ b/fortios/resource_firewall_proxyaddrgrp.go
@@ -287,7 +287,7 @@ func flattenFirewallProxyAddrgrpMember(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -341,7 +341,7 @@ func flattenFirewallProxyAddrgrpTagging(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_proxypolicy.go
+++ b/fortios/resource_firewall_proxypolicy.go
@@ -753,7 +753,7 @@ func flattenFirewallProxyPolicyAccessProxy(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -791,7 +791,7 @@ func flattenFirewallProxyPolicyAccessProxy6(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -829,7 +829,7 @@ func flattenFirewallProxyPolicySrcintf(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -867,7 +867,7 @@ func flattenFirewallProxyPolicyDstintf(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -905,7 +905,7 @@ func flattenFirewallProxyPolicySrcaddr(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -943,7 +943,7 @@ func flattenFirewallProxyPolicyPoolname(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -981,7 +981,7 @@ func flattenFirewallProxyPolicyDstaddr(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1019,7 +1019,7 @@ func flattenFirewallProxyPolicyZtnaEmsTag(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1073,7 +1073,7 @@ func flattenFirewallProxyPolicyInternetServiceName(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1111,7 +1111,7 @@ func flattenFirewallProxyPolicyInternetServiceId(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1149,7 +1149,7 @@ func flattenFirewallProxyPolicyInternetServiceGroup(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1187,7 +1187,7 @@ func flattenFirewallProxyPolicyInternetServiceCustom(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1225,7 +1225,7 @@ func flattenFirewallProxyPolicyInternetServiceCustomGroup(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1263,7 +1263,7 @@ func flattenFirewallProxyPolicyService(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1333,7 +1333,7 @@ func flattenFirewallProxyPolicySrcaddr6(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1371,7 +1371,7 @@ func flattenFirewallProxyPolicyDstaddr6(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1409,7 +1409,7 @@ func flattenFirewallProxyPolicyGroups(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1447,7 +1447,7 @@ func flattenFirewallProxyPolicyUsers(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_region.go
+++ b/fortios/resource_firewall_region.go
@@ -229,7 +229,7 @@ func flattenFirewallRegionCity(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_securitypolicy.go
+++ b/fortios/resource_firewall_securitypolicy.go
@@ -785,7 +785,7 @@ func flattenFirewallSecurityPolicySrcintfSp(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -823,7 +823,7 @@ func flattenFirewallSecurityPolicyDstintfSp(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -861,7 +861,7 @@ func flattenFirewallSecurityPolicySrcaddrSp(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -899,7 +899,7 @@ func flattenFirewallSecurityPolicyDstaddrSp(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -937,7 +937,7 @@ func flattenFirewallSecurityPolicySrcaddr4Sp(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -975,7 +975,7 @@ func flattenFirewallSecurityPolicyDstaddr4Sp(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1013,7 +1013,7 @@ func flattenFirewallSecurityPolicySrcaddr6Sp(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1051,7 +1051,7 @@ func flattenFirewallSecurityPolicyDstaddr6Sp(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1101,7 +1101,7 @@ func flattenFirewallSecurityPolicyInternetServiceNameSp(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1139,7 +1139,7 @@ func flattenFirewallSecurityPolicyInternetServiceIdSp(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1181,7 +1181,7 @@ func flattenFirewallSecurityPolicyInternetServiceGroupSp(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1219,7 +1219,7 @@ func flattenFirewallSecurityPolicyInternetServiceCustomSp(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1257,7 +1257,7 @@ func flattenFirewallSecurityPolicyInternetServiceCustomGroupSp(v interface{}, d 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1299,7 +1299,7 @@ func flattenFirewallSecurityPolicyInternetServiceSrcNameSp(v interface{}, d *sch
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1337,7 +1337,7 @@ func flattenFirewallSecurityPolicyInternetServiceSrcIdSp(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1379,7 +1379,7 @@ func flattenFirewallSecurityPolicyInternetServiceSrcGroupSp(v interface{}, d *sc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1417,7 +1417,7 @@ func flattenFirewallSecurityPolicyInternetServiceSrcCustomSp(v interface{}, d *s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1455,7 +1455,7 @@ func flattenFirewallSecurityPolicyInternetServiceSrcCustomGroupSp(v interface{},
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1497,7 +1497,7 @@ func flattenFirewallSecurityPolicyServiceSp(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1647,7 +1647,7 @@ func flattenFirewallSecurityPolicyApplicationSp(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1685,7 +1685,7 @@ func flattenFirewallSecurityPolicyAppCategorySp(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1723,7 +1723,7 @@ func flattenFirewallSecurityPolicyUrlCategorySp(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1761,7 +1761,7 @@ func flattenFirewallSecurityPolicyAppGroupSp(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1799,7 +1799,7 @@ func flattenFirewallSecurityPolicyGroupsSp(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1837,7 +1837,7 @@ func flattenFirewallSecurityPolicyUsersSp(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1875,7 +1875,7 @@ func flattenFirewallSecurityPolicyFssoGroupsSp(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_shapingpolicy.go
+++ b/fortios/resource_firewall_shapingpolicy.go
@@ -633,7 +633,7 @@ func flattenFirewallShapingPolicySrcaddr(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -671,7 +671,7 @@ func flattenFirewallShapingPolicyDstaddr(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -709,7 +709,7 @@ func flattenFirewallShapingPolicySrcaddr6(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -747,7 +747,7 @@ func flattenFirewallShapingPolicyDstaddr6(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -789,7 +789,7 @@ func flattenFirewallShapingPolicyInternetServiceName(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -827,7 +827,7 @@ func flattenFirewallShapingPolicyInternetServiceId(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -865,7 +865,7 @@ func flattenFirewallShapingPolicyInternetServiceGroup(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -903,7 +903,7 @@ func flattenFirewallShapingPolicyInternetServiceCustom(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -941,7 +941,7 @@ func flattenFirewallShapingPolicyInternetServiceCustomGroup(v interface{}, d *sc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -983,7 +983,7 @@ func flattenFirewallShapingPolicyInternetServiceSrcName(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1021,7 +1021,7 @@ func flattenFirewallShapingPolicyInternetServiceSrcId(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1059,7 +1059,7 @@ func flattenFirewallShapingPolicyInternetServiceSrcGroup(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1097,7 +1097,7 @@ func flattenFirewallShapingPolicyInternetServiceSrcCustom(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1135,7 +1135,7 @@ func flattenFirewallShapingPolicyInternetServiceSrcCustomGroup(v interface{}, d 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1173,7 +1173,7 @@ func flattenFirewallShapingPolicyService(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1215,7 +1215,7 @@ func flattenFirewallShapingPolicyUsers(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1253,7 +1253,7 @@ func flattenFirewallShapingPolicyGroups(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1291,7 +1291,7 @@ func flattenFirewallShapingPolicyApplication(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1329,7 +1329,7 @@ func flattenFirewallShapingPolicyAppCategory(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1367,7 +1367,7 @@ func flattenFirewallShapingPolicyAppGroup(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1405,7 +1405,7 @@ func flattenFirewallShapingPolicyUrlCategory(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1443,7 +1443,7 @@ func flattenFirewallShapingPolicySrcintf(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1481,7 +1481,7 @@ func flattenFirewallShapingPolicyDstintf(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_shapingprofile.go
+++ b/fortios/resource_firewall_shapingprofile.go
@@ -361,7 +361,7 @@ func flattenFirewallShapingProfileShapingEntries(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_sniffer.go
+++ b/fortios/resource_firewall_sniffer.go
@@ -536,7 +536,7 @@ func flattenFirewallSnifferIpThreatfeed(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -634,7 +634,7 @@ func flattenFirewallSnifferAnomaly(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_sslsshprofile.go
+++ b/fortios/resource_firewall_sslsshprofile.go
@@ -2436,7 +2436,7 @@ func flattenFirewallSslSshProfileSslExempt(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2596,7 +2596,7 @@ func flattenFirewallSslSshProfileSslServer(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewall_ttlpolicy.go
+++ b/fortios/resource_firewall_ttlpolicy.go
@@ -268,7 +268,7 @@ func flattenFirewallTtlPolicySrcaddr(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -306,7 +306,7 @@ func flattenFirewallTtlPolicyService(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vip.go
+++ b/fortios/resource_firewall_vip.go
@@ -824,7 +824,7 @@ func flattenFirewallVipSrcFilter(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "range", d)
+	dynamic_sort_subtable_natural(result, "range", d)
 	return result
 }
 
@@ -862,7 +862,7 @@ func flattenFirewallVipService(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -904,7 +904,7 @@ func flattenFirewallVipExtaddr(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -954,7 +954,7 @@ func flattenFirewallVipMappedip(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "range", d)
+	dynamic_sort_subtable_natural(result, "range", d)
 	return result
 }
 
@@ -1044,7 +1044,7 @@ func flattenFirewallVipSrcintfFilter(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 
@@ -1182,7 +1182,7 @@ func flattenFirewallVipRealservers(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1348,7 +1348,7 @@ func flattenFirewallVipSslCipherSuites(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "priority", d)
+	dynamic_sort_subtable_natural(result, "priority", d)
 	return result
 }
 
@@ -1410,7 +1410,7 @@ func flattenFirewallVipSslServerCipherSuites(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "priority", d)
+	dynamic_sort_subtable_natural(result, "priority", d)
 	return result
 }
 
@@ -1564,7 +1564,7 @@ func flattenFirewallVipMonitor(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vip46.go
+++ b/fortios/resource_firewall_vip46.go
@@ -387,7 +387,7 @@ func flattenFirewallVip46SrcintfFilter(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 
@@ -433,7 +433,7 @@ func flattenFirewallVip46SrcFilter(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "range", d)
+	dynamic_sort_subtable_natural(result, "range", d)
 	return result
 }
 
@@ -589,7 +589,7 @@ func flattenFirewallVip46Realservers(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -663,7 +663,7 @@ func flattenFirewallVip46Monitor(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vip6.go
+++ b/fortios/resource_firewall_vip6.go
@@ -723,7 +723,7 @@ func flattenFirewallVip6SrcFilter(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "range", d)
+	dynamic_sort_subtable_natural(result, "range", d)
 	return result
 }
 
@@ -909,7 +909,7 @@ func flattenFirewallVip6Realservers(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1067,7 +1067,7 @@ func flattenFirewallVip6SslCipherSuites(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "priority", d)
+	dynamic_sort_subtable_natural(result, "priority", d)
 	return result
 }
 
@@ -1129,7 +1129,7 @@ func flattenFirewallVip6SslServerCipherSuites(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "priority", d)
+	dynamic_sort_subtable_natural(result, "priority", d)
 	return result
 }
 
@@ -1283,7 +1283,7 @@ func flattenFirewallVip6Monitor(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vip64.go
+++ b/fortios/resource_firewall_vip64.go
@@ -381,7 +381,7 @@ func flattenFirewallVip64SrcFilter(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "range", d)
+	dynamic_sort_subtable_natural(result, "range", d)
 	return result
 }
 
@@ -537,7 +537,7 @@ func flattenFirewallVip64Realservers(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -611,7 +611,7 @@ func flattenFirewallVip64Monitor(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vipgrp.go
+++ b/fortios/resource_firewall_vipgrp.go
@@ -256,7 +256,7 @@ func flattenFirewallVipgrpMember(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vipgrp46.go
+++ b/fortios/resource_firewall_vipgrp46.go
@@ -247,7 +247,7 @@ func flattenFirewallVipgrp46Member(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vipgrp6.go
+++ b/fortios/resource_firewall_vipgrp6.go
@@ -247,7 +247,7 @@ func flattenFirewallVipgrp6Member(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewall_vipgrp64.go
+++ b/fortios/resource_firewall_vipgrp64.go
@@ -247,7 +247,7 @@ func flattenFirewallVipgrp64Member(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewallconsolidated_policy.go
+++ b/fortios/resource_firewallconsolidated_policy.go
@@ -920,7 +920,7 @@ func flattenFirewallConsolidatedPolicySrcintf(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -958,7 +958,7 @@ func flattenFirewallConsolidatedPolicyDstintf(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -996,7 +996,7 @@ func flattenFirewallConsolidatedPolicySrcaddr4(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1034,7 +1034,7 @@ func flattenFirewallConsolidatedPolicyDstaddr4(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1072,7 +1072,7 @@ func flattenFirewallConsolidatedPolicySrcaddr6(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1110,7 +1110,7 @@ func flattenFirewallConsolidatedPolicyDstaddr6(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1164,7 +1164,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceName(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1202,7 +1202,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceId(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1240,7 +1240,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceGroup(v interface{}, d *sch
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1278,7 +1278,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceCustom(v interface{}, d *sc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1316,7 +1316,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceCustomGroup(v interface{}, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1358,7 +1358,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceSrcName(v interface{}, d *s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1396,7 +1396,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceSrcId(v interface{}, d *sch
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1434,7 +1434,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceSrcGroup(v interface{}, d *
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1472,7 +1472,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceSrcCustom(v interface{}, d 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1510,7 +1510,7 @@ func flattenFirewallConsolidatedPolicyInternetServiceSrcCustomGroup(v interface{
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1564,7 +1564,7 @@ func flattenFirewallConsolidatedPolicyService(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1702,7 +1702,7 @@ func flattenFirewallConsolidatedPolicyGroups(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1740,7 +1740,7 @@ func flattenFirewallConsolidatedPolicyUsers(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1858,7 +1858,7 @@ func flattenFirewallConsolidatedPolicyPoolname4(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1896,7 +1896,7 @@ func flattenFirewallConsolidatedPolicyPoolname6(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1958,7 +1958,7 @@ func flattenFirewallConsolidatedPolicyFssoGroups(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1996,7 +1996,7 @@ func flattenFirewallConsolidatedPolicyApplication(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2034,7 +2034,7 @@ func flattenFirewallConsolidatedPolicyAppCategory(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2072,7 +2072,7 @@ func flattenFirewallConsolidatedPolicyUrlCategory(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2110,7 +2110,7 @@ func flattenFirewallConsolidatedPolicyAppGroup(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewallschedule_group.go
+++ b/fortios/resource_firewallschedule_group.go
@@ -229,7 +229,7 @@ func flattenFirewallScheduleGroupMember(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_firewallservice_custom.go
+++ b/fortios/resource_firewallservice_custom.go
@@ -454,7 +454,7 @@ func flattenFirewallServiceCustomAppCategory(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -492,7 +492,7 @@ func flattenFirewallServiceCustomApplication(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_firewallwildcardfqdn_group.go
+++ b/fortios/resource_firewallwildcardfqdn_group.go
@@ -244,7 +244,7 @@ func flattenFirewallWildcardFqdnGroupMember(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_icap_profile.go
+++ b/fortios/resource_icap_profile.go
@@ -501,7 +501,7 @@ func flattenIcapProfileIcapHeaders(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -575,7 +575,7 @@ func flattenIcapProfileRespmodForwardRules(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_ips_decoder.go
+++ b/fortios/resource_ips_decoder.go
@@ -232,7 +232,7 @@ func flattenIpsDecoderParameter(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_ips_rule.go
+++ b/fortios/resource_ips_rule.go
@@ -359,7 +359,7 @@ func flattenIpsRuleMetadata(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_ips_sensor.go
+++ b/fortios/resource_ips_sensor.go
@@ -666,7 +666,7 @@ func flattenIpsSensorEntries(v interface{}, d *schema.ResourceData, pre string, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -990,7 +990,7 @@ func flattenIpsSensorFilter(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1125,7 +1125,7 @@ func flattenIpsSensorOverride(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "rule_id", d)
+	dynamic_sort_subtable_natural(result, "rule_id", d)
 	return result
 }
 

--- a/fortios/resource_log_setting.go
+++ b/fortios/resource_log_setting.go
@@ -372,7 +372,7 @@ func flattenLogSettingCustomLogFields(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "field_id", d)
+	dynamic_sort_subtable_natural(result, "field_id", d)
 	return result
 }
 

--- a/fortios/resource_log_threatweight.go
+++ b/fortios/resource_log_threatweight.go
@@ -755,7 +755,7 @@ func flattenLogThreatWeightWeb(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -813,7 +813,7 @@ func flattenLogThreatWeightGeolocation(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -871,7 +871,7 @@ func flattenLogThreatWeightApplication(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logdisk_filter.go
+++ b/fortios/resource_logdisk_filter.go
@@ -429,7 +429,7 @@ func flattenLogDiskFilterFreeStyle(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer2_filter.go
+++ b/fortios/resource_logfortianalyzer2_filter.go
@@ -339,7 +339,7 @@ func flattenLogFortianalyzer2FilterFreeStyle(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer2_overridefilter.go
+++ b/fortios/resource_logfortianalyzer2_overridefilter.go
@@ -339,7 +339,7 @@ func flattenLogFortianalyzer2OverrideFilterFreeStyle(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer2_overridesetting.go
+++ b/fortios/resource_logfortianalyzer2_overridesetting.go
@@ -352,7 +352,7 @@ func flattenLogFortianalyzer2OverrideSettingSerial(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer2_setting.go
+++ b/fortios/resource_logfortianalyzer2_setting.go
@@ -334,7 +334,7 @@ func flattenLogFortianalyzer2SettingSerial(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer3_filter.go
+++ b/fortios/resource_logfortianalyzer3_filter.go
@@ -339,7 +339,7 @@ func flattenLogFortianalyzer3FilterFreeStyle(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer3_overridefilter.go
+++ b/fortios/resource_logfortianalyzer3_overridefilter.go
@@ -339,7 +339,7 @@ func flattenLogFortianalyzer3OverrideFilterFreeStyle(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer3_overridesetting.go
+++ b/fortios/resource_logfortianalyzer3_overridesetting.go
@@ -352,7 +352,7 @@ func flattenLogFortianalyzer3OverrideSettingSerial(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer3_setting.go
+++ b/fortios/resource_logfortianalyzer3_setting.go
@@ -334,7 +334,7 @@ func flattenLogFortianalyzer3SettingSerial(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer_filter.go
+++ b/fortios/resource_logfortianalyzer_filter.go
@@ -339,7 +339,7 @@ func flattenLogFortianalyzerFilterFreeStyle(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer_overridefilter.go
+++ b/fortios/resource_logfortianalyzer_overridefilter.go
@@ -339,7 +339,7 @@ func flattenLogFortianalyzerOverrideFilterFreeStyle(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer_overridesetting.go
+++ b/fortios/resource_logfortianalyzer_overridesetting.go
@@ -352,7 +352,7 @@ func flattenLogFortianalyzerOverrideSettingSerial(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzer_setting.go
+++ b/fortios/resource_logfortianalyzer_setting.go
@@ -334,7 +334,7 @@ func flattenLogFortianalyzerSettingSerial(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzercloud_filter.go
+++ b/fortios/resource_logfortianalyzercloud_filter.go
@@ -311,7 +311,7 @@ func flattenLogFortianalyzerCloudFilterFreeStyle(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzercloud_overridefilter.go
+++ b/fortios/resource_logfortianalyzercloud_overridefilter.go
@@ -311,7 +311,7 @@ func flattenLogFortianalyzerCloudOverrideFilterFreeStyle(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortianalyzercloud_setting.go
+++ b/fortios/resource_logfortianalyzercloud_setting.go
@@ -302,7 +302,7 @@ func flattenLogFortianalyzerCloudSettingSerial(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_logfortiguard_filter.go
+++ b/fortios/resource_logfortiguard_filter.go
@@ -339,7 +339,7 @@ func flattenLogFortiguardFilterFreeStyle(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logfortiguard_overridefilter.go
+++ b/fortios/resource_logfortiguard_overridefilter.go
@@ -339,7 +339,7 @@ func flattenLogFortiguardOverrideFilterFreeStyle(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logmemory_filter.go
+++ b/fortios/resource_logmemory_filter.go
@@ -420,7 +420,7 @@ func flattenLogMemoryFilterFreeStyle(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_lognulldevice_filter.go
+++ b/fortios/resource_lognulldevice_filter.go
@@ -330,7 +330,7 @@ func flattenLogNullDeviceFilterFreeStyle(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd2_filter.go
+++ b/fortios/resource_logsyslogd2_filter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd2FilterFreeStyle(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd2_overridefilter.go
+++ b/fortios/resource_logsyslogd2_overridefilter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd2OverrideFilterFreeStyle(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd2_overridesetting.go
+++ b/fortios/resource_logsyslogd2_overridesetting.go
@@ -339,7 +339,7 @@ func flattenLogSyslogd2OverrideSettingCustomFieldName(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd2_setting.go
+++ b/fortios/resource_logsyslogd2_setting.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd2SettingCustomFieldName(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd3_filter.go
+++ b/fortios/resource_logsyslogd3_filter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd3FilterFreeStyle(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd3_overridefilter.go
+++ b/fortios/resource_logsyslogd3_overridefilter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd3OverrideFilterFreeStyle(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd3_overridesetting.go
+++ b/fortios/resource_logsyslogd3_overridesetting.go
@@ -339,7 +339,7 @@ func flattenLogSyslogd3OverrideSettingCustomFieldName(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd3_setting.go
+++ b/fortios/resource_logsyslogd3_setting.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd3SettingCustomFieldName(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd4_filter.go
+++ b/fortios/resource_logsyslogd4_filter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd4FilterFreeStyle(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd4_overridefilter.go
+++ b/fortios/resource_logsyslogd4_overridefilter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd4OverrideFilterFreeStyle(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd4_overridesetting.go
+++ b/fortios/resource_logsyslogd4_overridesetting.go
@@ -339,7 +339,7 @@ func flattenLogSyslogd4OverrideSettingCustomFieldName(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd4_setting.go
+++ b/fortios/resource_logsyslogd4_setting.go
@@ -330,7 +330,7 @@ func flattenLogSyslogd4SettingCustomFieldName(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd_filter.go
+++ b/fortios/resource_logsyslogd_filter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogdFilterFreeStyle(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd_overridefilter.go
+++ b/fortios/resource_logsyslogd_overridefilter.go
@@ -330,7 +330,7 @@ func flattenLogSyslogdOverrideFilterFreeStyle(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd_overridesetting.go
+++ b/fortios/resource_logsyslogd_overridesetting.go
@@ -339,7 +339,7 @@ func flattenLogSyslogdOverrideSettingCustomFieldName(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logsyslogd_setting.go
+++ b/fortios/resource_logsyslogd_setting.go
@@ -330,7 +330,7 @@ func flattenLogSyslogdSettingCustomFieldName(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_logwebtrends_filter.go
+++ b/fortios/resource_logwebtrends_filter.go
@@ -330,7 +330,7 @@ func flattenLogWebtrendsFilterFreeStyle(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_nsxt_servicechain.go
+++ b/fortios/resource_nsxt_servicechain.go
@@ -266,7 +266,7 @@ func flattenNsxtServiceChainServiceIndex(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_report_chart.go
+++ b/fortios/resource_report_chart.go
@@ -599,7 +599,7 @@ func flattenReportChartDrillDownCharts(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1035,7 +1035,7 @@ func flattenReportChartColumn(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_report_dataset.go
+++ b/fortios/resource_report_dataset.go
@@ -302,7 +302,7 @@ func flattenReportDatasetField(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -370,7 +370,7 @@ func flattenReportDatasetParameters(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_report_layout.go
+++ b/fortios/resource_report_layout.go
@@ -1090,7 +1090,7 @@ func flattenReportLayoutBodyItem(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_accesslist.go
+++ b/fortios/resource_router_accesslist.go
@@ -283,7 +283,7 @@ func flattenRouterAccessListRule(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_accesslist6.go
+++ b/fortios/resource_router_accesslist6.go
@@ -272,7 +272,7 @@ func flattenRouterAccessList6Rule(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_aspathlist.go
+++ b/fortios/resource_router_aspathlist.go
@@ -241,7 +241,7 @@ func flattenRouterAspathListRule(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_bfd.go
+++ b/fortios/resource_router_bfd.go
@@ -193,7 +193,7 @@ func flattenRouterBfdNeighbor(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 

--- a/fortios/resource_router_bfd6.go
+++ b/fortios/resource_router_bfd6.go
@@ -193,7 +193,7 @@ func flattenRouterBfd6Neighbor(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip6_address", d)
+	dynamic_sort_subtable_natural(result, "ip6_address", d)
 	return result
 }
 

--- a/fortios/resource_router_bgp.go
+++ b/fortios/resource_router_bgp.go
@@ -1922,7 +1922,7 @@ func flattenRouterBgpConfederationPeers(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "peer", d)
+	dynamic_sort_subtable_natural(result, "peer", d)
 	return result
 }
 
@@ -2054,7 +2054,7 @@ func flattenRouterBgpAggregateAddress(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2129,7 +2129,7 @@ func flattenRouterBgpAggregateAddress6(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2729,7 +2729,7 @@ func flattenRouterBgpNeighbor(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -3765,7 +3765,7 @@ func flattenRouterBgpNeighborGroup(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -4173,7 +4173,7 @@ func flattenRouterBgpNeighborRange(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -4248,7 +4248,7 @@ func flattenRouterBgpNeighborRange6(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -4322,7 +4322,7 @@ func flattenRouterBgpNetwork(v interface{}, d *schema.ResourceData, pre string, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -4407,7 +4407,7 @@ func flattenRouterBgpNetwork6(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -4473,7 +4473,7 @@ func flattenRouterBgpRedistribute(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -4531,7 +4531,7 @@ func flattenRouterBgpRedistribute6(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -4595,7 +4595,7 @@ func flattenRouterBgpAdminDistance(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -4658,7 +4658,7 @@ func flattenRouterBgpVrfLeak(v interface{}, d *schema.ResourceData, pre string, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vrf", d)
+	dynamic_sort_subtable_natural(result, "vrf", d)
 	return result
 }
 
@@ -4759,7 +4759,7 @@ func flattenRouterBgpVrfLeak6(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vrf", d)
+	dynamic_sort_subtable_natural(result, "vrf", d)
 	return result
 }
 

--- a/fortios/resource_router_communitylist.go
+++ b/fortios/resource_router_communitylist.go
@@ -261,7 +261,7 @@ func flattenRouterCommunityListRule(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_isis.go
+++ b/fortios/resource_router_isis.go
@@ -822,7 +822,7 @@ func flattenRouterIsisIsisNet(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1046,7 +1046,7 @@ func flattenRouterIsisIsisInterface(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1212,7 +1212,7 @@ func flattenRouterIsisSummaryAddress(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1277,7 +1277,7 @@ func flattenRouterIsisSummaryAddress6(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1353,7 +1353,7 @@ func flattenRouterIsisRedistribute(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "protocol", d)
+	dynamic_sort_subtable_natural(result, "protocol", d)
 	return result
 }
 
@@ -1441,7 +1441,7 @@ func flattenRouterIsisRedistribute6(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "protocol", d)
+	dynamic_sort_subtable_natural(result, "protocol", d)
 	return result
 }
 

--- a/fortios/resource_router_keychain.go
+++ b/fortios/resource_router_keychain.go
@@ -284,7 +284,7 @@ func flattenRouterKeyChainKey(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_multicast.go
+++ b/fortios/resource_router_multicast.go
@@ -1015,7 +1015,7 @@ func flattenRouterMulticastInterface(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_multicast6.go
+++ b/fortios/resource_router_multicast6.go
@@ -257,7 +257,7 @@ func flattenRouterMulticast6Interface(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_multicastflow.go
+++ b/fortios/resource_router_multicastflow.go
@@ -250,7 +250,7 @@ func flattenRouterMulticastFlowFlows(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_ospf.go
+++ b/fortios/resource_router_ospf.go
@@ -1023,7 +1023,7 @@ func flattenRouterOspfArea(v interface{}, d *schema.ResourceData, pre string, sv
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1607,7 +1607,7 @@ func flattenRouterOspfOspfInterface(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1806,7 +1806,7 @@ func flattenRouterOspfNetwork(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1887,7 +1887,7 @@ func flattenRouterOspfNeighbor(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1941,7 +1941,7 @@ func flattenRouterOspfPassiveInterface(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1997,7 +1997,7 @@ func flattenRouterOspfSummaryAddress(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2066,7 +2066,7 @@ func flattenRouterOspfDistributeList(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2142,7 +2142,7 @@ func flattenRouterOspfRedistribute(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_ospf6.go
+++ b/fortios/resource_router_ospf6.go
@@ -815,7 +815,7 @@ func flattenRouterOspf6Area(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1335,7 +1335,7 @@ func flattenRouterOspf6Ospf6Interface(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1597,7 +1597,7 @@ func flattenRouterOspf6Redistribute(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1651,7 +1651,7 @@ func flattenRouterOspf6PassiveInterface(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1707,7 +1707,7 @@ func flattenRouterOspf6SummaryAddress(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_policy.go
+++ b/fortios/resource_router_policy.go
@@ -384,7 +384,7 @@ func flattenRouterPolicyInputDevice(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -426,7 +426,7 @@ func flattenRouterPolicySrc(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "subnet", d)
+	dynamic_sort_subtable_natural(result, "subnet", d)
 	return result
 }
 
@@ -464,7 +464,7 @@ func flattenRouterPolicySrcaddr(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -506,7 +506,7 @@ func flattenRouterPolicyDst(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "subnet", d)
+	dynamic_sort_subtable_natural(result, "subnet", d)
 	return result
 }
 
@@ -544,7 +544,7 @@ func flattenRouterPolicyDstaddr(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -634,7 +634,7 @@ func flattenRouterPolicyInternetServiceId(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -672,7 +672,7 @@ func flattenRouterPolicyInternetServiceCustom(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_prefixlist.go
+++ b/fortios/resource_router_prefixlist.go
@@ -285,7 +285,7 @@ func flattenRouterPrefixListRule(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_prefixlist6.go
+++ b/fortios/resource_router_prefixlist6.go
@@ -285,7 +285,7 @@ func flattenRouterPrefixList6Rule(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_rip.go
+++ b/fortios/resource_router_rip.go
@@ -493,7 +493,7 @@ func flattenRouterRipDistance(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -574,7 +574,7 @@ func flattenRouterRipDistributeList(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -634,7 +634,7 @@ func flattenRouterRipNeighbor(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -682,7 +682,7 @@ func flattenRouterRipNetwork(v interface{}, d *schema.ResourceData, pre string, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -761,7 +761,7 @@ func flattenRouterRipOffsetList(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -819,7 +819,7 @@ func flattenRouterRipPassiveInterface(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -875,7 +875,7 @@ func flattenRouterRipRedistribute(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -999,7 +999,7 @@ func flattenRouterRipInterface(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_ripng.go
+++ b/fortios/resource_router_ripng.go
@@ -471,7 +471,7 @@ func flattenRouterRipngDistance(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -545,7 +545,7 @@ func flattenRouterRipngDistributeList(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -611,7 +611,7 @@ func flattenRouterRipngNeighbor(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -663,7 +663,7 @@ func flattenRouterRipngNetwork(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -711,7 +711,7 @@ func flattenRouterRipngAggregateAddress(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -783,7 +783,7 @@ func flattenRouterRipngOffsetList(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -841,7 +841,7 @@ func flattenRouterRipngPassiveInterface(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -897,7 +897,7 @@ func flattenRouterRipngRedistribute(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -977,7 +977,7 @@ func flattenRouterRipngInterface(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_routemap.go
+++ b/fortios/resource_router_routemap.go
@@ -742,7 +742,7 @@ func flattenRouterRouteMapRule(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_router_static.go
+++ b/fortios/resource_router_static.go
@@ -378,7 +378,7 @@ func flattenRouterStaticSdwanZone(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_router_static6.go
+++ b/fortios/resource_router_static6.go
@@ -336,7 +336,7 @@ func flattenRouterStatic6SdwanZone(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_routerbgp_neighbor.go
+++ b/fortios/resource_routerbgp_neighbor.go
@@ -1108,7 +1108,7 @@ func flattenRouterbgpNeighborConditionalAdvertise(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "advertise_routemap", d)
+	dynamic_sort_subtable_natural(result, "advertise_routemap", d)
 	return result
 }
 
@@ -1166,7 +1166,7 @@ func flattenRouterbgpNeighborConditionalAdvertise6(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "advertise_routemap", d)
+	dynamic_sort_subtable_natural(result, "advertise_routemap", d)
 	return result
 }
 

--- a/fortios/resource_routerospf6_ospf6interface.go
+++ b/fortios/resource_routerospf6_ospf6interface.go
@@ -434,7 +434,7 @@ func flattenRouterospf6Ospf6InterfaceIpsecKeys(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "spi", d)
+	dynamic_sort_subtable_natural(result, "spi", d)
 	return result
 }
 
@@ -498,7 +498,7 @@ func flattenRouterospf6Ospf6InterfaceNeighbor(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip6", d)
+	dynamic_sort_subtable_natural(result, "ip6", d)
 	return result
 }
 

--- a/fortios/resource_routerospf_ospfinterface.go
+++ b/fortios/resource_routerospf_ospfinterface.go
@@ -451,7 +451,7 @@ func flattenRouterospfOspfInterfaceMd5Keys(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_sctpfilter_profile.go
+++ b/fortios/resource_sctpfilter_profile.go
@@ -261,7 +261,7 @@ func flattenSctpFilterProfilePpidFilters(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_spamfilter_bwl.go
+++ b/fortios/resource_spamfilter_bwl.go
@@ -324,7 +324,7 @@ func flattenSpamfilterBwlEntries(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_spamfilter_bword.go
+++ b/fortios/resource_spamfilter_bword.go
@@ -314,7 +314,7 @@ func flattenSpamfilterBwordEntries(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_spamfilter_dnsbl.go
+++ b/fortios/resource_spamfilter_dnsbl.go
@@ -269,7 +269,7 @@ func flattenSpamfilterDnsblEntries(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_spamfilter_iptrust.go
+++ b/fortios/resource_spamfilter_iptrust.go
@@ -279,7 +279,7 @@ func flattenSpamfilterIptrustEntries(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_spamfilter_mheader.go
+++ b/fortios/resource_spamfilter_mheader.go
@@ -292,7 +292,7 @@ func flattenSpamfilterMheaderEntries(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_sshfilter_profile.go
+++ b/fortios/resource_sshfilter_profile.go
@@ -385,7 +385,7 @@ func flattenSshFilterProfileShellCommands(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_dynamicportpolicy.go
+++ b/fortios/resource_switchcontroller_dynamicportpolicy.go
@@ -413,7 +413,7 @@ func flattenSwitchControllerDynamicPortPolicyPolicy(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_flowtracking.go
+++ b/fortios/resource_switchcontroller_flowtracking.go
@@ -332,7 +332,7 @@ func flattenSwitchControllerFlowTrackingAggregates(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_global.go
+++ b/fortios/resource_switchcontroller_global.go
@@ -305,7 +305,7 @@ func flattenSwitchControllerGlobalDisableDiscovery(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -389,7 +389,7 @@ func flattenSwitchControllerGlobalCustomCommand(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "command_entry", d)
+	dynamic_sort_subtable_natural(result, "command_entry", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_lldpprofile.go
+++ b/fortios/resource_switchcontroller_lldpprofile.go
@@ -420,7 +420,7 @@ func flattenSwitchControllerLldpProfileMedNetworkPolicy(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -494,7 +494,7 @@ func flattenSwitchControllerLldpProfileMedLocationService(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -558,7 +558,7 @@ func flattenSwitchControllerLldpProfileCustomTlvs(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_managedswitch.go
+++ b/fortios/resource_switchcontroller_managedswitch.go
@@ -2256,7 +2256,7 @@ func flattenSwitchControllerManagedSwitchPorts(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "port_name", d)
+	dynamic_sort_subtable_natural(result, "port_name", d)
 	return result
 }
 
@@ -2815,7 +2815,7 @@ func flattenSwitchControllerManagedSwitchIpSourceGuard(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "port", d)
+	dynamic_sort_subtable_natural(result, "port", d)
 	return result
 }
 
@@ -3023,7 +3023,7 @@ func flattenSwitchControllerManagedSwitchStpInstance(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -3267,7 +3267,7 @@ func flattenSwitchControllerManagedSwitchSnmpCommunity(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -3458,7 +3458,7 @@ func flattenSwitchControllerManagedSwitchSnmpUser(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -3634,7 +3634,7 @@ func flattenSwitchControllerManagedSwitchRemoteLog(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -3789,7 +3789,7 @@ func flattenSwitchControllerManagedSwitchMirror(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -3943,7 +3943,7 @@ func flattenSwitchControllerManagedSwitchStaticMac(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -4007,7 +4007,7 @@ func flattenSwitchControllerManagedSwitchCustomCommand(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "command_entry", d)
+	dynamic_sort_subtable_natural(result, "command_entry", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_quarantine.go
+++ b/fortios/resource_switchcontroller_quarantine.go
@@ -228,7 +228,7 @@ func flattenSwitchControllerQuarantineTargets(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "mac", d)
+	dynamic_sort_subtable_natural(result, "mac", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_snmpcommunity.go
+++ b/fortios/resource_switchcontroller_snmpcommunity.go
@@ -309,7 +309,7 @@ func flattenSwitchControllerSnmpCommunityHosts(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_stpinstance.go
+++ b/fortios/resource_switchcontroller_stpinstance.go
@@ -220,7 +220,7 @@ func flattenSwitchControllerStpInstanceVlanRange(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vlan_name", d)
+	dynamic_sort_subtable_natural(result, "vlan_name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_switchgroup.go
+++ b/fortios/resource_switchcontroller_switchgroup.go
@@ -252,7 +252,7 @@ func flattenSwitchControllerSwitchGroupMembers(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_trafficsniffer.go
+++ b/fortios/resource_switchcontroller_trafficsniffer.go
@@ -273,7 +273,7 @@ func flattenSwitchControllerTrafficSnifferTargetMac(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "mac", d)
+	dynamic_sort_subtable_natural(result, "mac", d)
 	return result
 }
 
@@ -321,7 +321,7 @@ func flattenSwitchControllerTrafficSnifferTargetIp(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -381,7 +381,7 @@ func flattenSwitchControllerTrafficSnifferTargetPort(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "switch_id", d)
+	dynamic_sort_subtable_natural(result, "switch_id", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_vlan.go
+++ b/fortios/resource_switchcontroller_vlan.go
@@ -394,7 +394,7 @@ func flattenSwitchControllerVlanSelectedUsergroups(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontroller_vlanpolicy.go
+++ b/fortios/resource_switchcontroller_vlanpolicy.go
@@ -274,7 +274,7 @@ func flattenSwitchControllerVlanPolicyAllowedVlans(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vlan_name", d)
+	dynamic_sort_subtable_natural(result, "vlan_name", d)
 	return result
 }
 
@@ -312,7 +312,7 @@ func flattenSwitchControllerVlanPolicyUntaggedVlans(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vlan_name", d)
+	dynamic_sort_subtable_natural(result, "vlan_name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontrollerautoconfig_custom.go
+++ b/fortios/resource_switchcontrollerautoconfig_custom.go
@@ -231,7 +231,7 @@ func flattenSwitchControllerAutoConfigCustomSwitchBinding(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "switch_id", d)
+	dynamic_sort_subtable_natural(result, "switch_id", d)
 	return result
 }
 

--- a/fortios/resource_switchcontrollerqos_ipdscpmap.go
+++ b/fortios/resource_switchcontrollerqos_ipdscpmap.go
@@ -274,7 +274,7 @@ func flattenSwitchControllerQosIpDscpMapMap(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontrollerqos_queuepolicy.go
+++ b/fortios/resource_switchcontrollerqos_queuepolicy.go
@@ -324,7 +324,7 @@ func flattenSwitchControllerQosQueuePolicyCosQueue(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_switchcontrollersecuritypolicy_8021X.go
+++ b/fortios/resource_switchcontrollersecuritypolicy_8021X.go
@@ -321,7 +321,7 @@ func flattenSwitchControllerSecurityPolicy8021XUserGroup(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_acme.go
+++ b/fortios/resource_system_acme.go
@@ -221,7 +221,7 @@ func flattenSystemAcmeInterface(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 
@@ -289,7 +289,7 @@ func flattenSystemAcmeAccounts(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_admin.go
+++ b/fortios/resource_system_admin.go
@@ -913,7 +913,7 @@ func flattenSystemAdminVdom(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1017,7 +1017,7 @@ func flattenSystemAdminGuiDashboard(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1347,7 +1347,7 @@ func flattenSystemAdminGuestUsergroups(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1409,7 +1409,7 @@ func flattenSystemAdminLoginTime(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "usr_name", d)
+	dynamic_sort_subtable_natural(result, "usr_name", d)
 	return result
 }
 
@@ -1455,7 +1455,7 @@ func flattenSystemAdminGuiGlobalMenuFavorites(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1493,7 +1493,7 @@ func flattenSystemAdminGuiVdomMenuFavorites(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1531,7 +1531,7 @@ func flattenSystemAdminGuiNewFeatureAcknowledge(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_alarm.go
+++ b/fortios/resource_system_alarm.go
@@ -383,7 +383,7 @@ func flattenSystemAlarmGroups(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_apiuser.go
+++ b/fortios/resource_system_apiuser.go
@@ -299,7 +299,7 @@ func flattenSystemApiUserVdom(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -371,7 +371,7 @@ func flattenSystemApiUserTrusthost(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_automationaction.go
+++ b/fortios/resource_system_automationaction.go
@@ -526,7 +526,7 @@ func flattenSystemAutomationActionEmailTo(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -720,7 +720,7 @@ func flattenSystemAutomationActionHeaders(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "header", d)
+	dynamic_sort_subtable_natural(result, "header", d)
 	return result
 }
 
@@ -778,7 +778,7 @@ func flattenSystemAutomationActionSdnConnector(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_automationdestination.go
+++ b/fortios/resource_system_automationdestination.go
@@ -235,7 +235,7 @@ func flattenSystemAutomationDestinationDestination(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_automationstitch.go
+++ b/fortios/resource_system_automationstitch.go
@@ -308,7 +308,7 @@ func flattenSystemAutomationStitchActions(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -358,7 +358,7 @@ func flattenSystemAutomationStitchAction(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -396,7 +396,7 @@ func flattenSystemAutomationStitchDestination(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_automationtrigger.go
+++ b/fortios/resource_system_automationtrigger.go
@@ -384,7 +384,7 @@ func flattenSystemAutomationTriggerFields(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_centralmanagement.go
+++ b/fortios/resource_system_centralmanagement.go
@@ -395,7 +395,7 @@ func flattenSystemCentralManagementServerList(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_clustersync.go
+++ b/fortios/resource_system_clustersync.go
@@ -360,7 +360,7 @@ func flattenSystemClusterSyncSyncvd(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -398,7 +398,7 @@ func flattenSystemClusterSyncDownIntfsBeforeSessSync(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_csf.go
+++ b/fortios/resource_system_csf.go
@@ -501,7 +501,7 @@ func flattenSystemCsfTrustedList(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "serial", d)
+	dynamic_sort_subtable_natural(result, "serial", d)
 	return result
 }
 
@@ -575,7 +575,7 @@ func flattenSystemCsfFabricConnector(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "serial", d)
+	dynamic_sort_subtable_natural(result, "serial", d)
 	return result
 }
 
@@ -669,7 +669,7 @@ func flattenSystemCsfFabricDevice(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_ddns.go
+++ b/fortios/resource_system_ddns.go
@@ -340,7 +340,7 @@ func flattenSystemDdnsDdnsServerAddr(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "addr", d)
+	dynamic_sort_subtable_natural(result, "addr", d)
 	return result
 }
 
@@ -442,7 +442,7 @@ func flattenSystemDdnsMonitorInterface(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_system_dns.go
+++ b/fortios/resource_system_dns.go
@@ -310,7 +310,7 @@ func flattenSystemDnsServerHostname(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "hostname", d)
+	dynamic_sort_subtable_natural(result, "hostname", d)
 	return result
 }
 
@@ -348,7 +348,7 @@ func flattenSystemDnsDomain(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "domain", d)
+	dynamic_sort_subtable_natural(result, "domain", d)
 	return result
 }
 

--- a/fortios/resource_system_dnsdatabase.go
+++ b/fortios/resource_system_dnsdatabase.go
@@ -434,7 +434,7 @@ func flattenSystemDnsDatabaseDnsEntry(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_federatedupgrade.go
+++ b/fortios/resource_system_federatedupgrade.go
@@ -291,7 +291,7 @@ func flattenSystemFederatedUpgradeNodeList(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "serial", d)
+	dynamic_sort_subtable_natural(result, "serial", d)
 	return result
 }
 

--- a/fortios/resource_system_geoipoverride.go
+++ b/fortios/resource_system_geoipoverride.go
@@ -285,7 +285,7 @@ func flattenSystemGeoipOverrideIpRange(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -343,7 +343,7 @@ func flattenSystemGeoipOverrideIp6Range(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_ha.go
+++ b/fortios/resource_system_ha.go
@@ -852,7 +852,7 @@ func flattenSystemHaHaMgmtInterfaces(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -947,7 +947,7 @@ func flattenSystemHaUnicastPeers(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_interface.go
+++ b/fortios/resource_system_interface.go
@@ -2046,7 +2046,7 @@ func flattenSystemInterfaceClientOptions(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2199,7 +2199,7 @@ func flattenSystemInterfaceFailAlertInterfaces(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2618,7 +2618,7 @@ func flattenSystemInterfaceMember(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 
@@ -2704,7 +2704,7 @@ func flattenSystemInterfaceManagedDevice(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2802,7 +2802,7 @@ func flattenSystemInterfaceSecurityGroups(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2998,7 +2998,7 @@ func flattenSystemInterfaceVrrp(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vrid", d)
+	dynamic_sort_subtable_natural(result, "vrid", d)
 	return result
 }
 
@@ -3185,7 +3185,7 @@ func flattenSystemInterfaceSecondaryip(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -3337,7 +3337,7 @@ func flattenSystemInterfaceDhcpSnoopingServerList(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -3427,7 +3427,7 @@ func flattenSystemInterfaceTagging(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_ipsecaggregate.go
+++ b/fortios/resource_system_ipsecaggregate.go
@@ -225,7 +225,7 @@ func flattenSystemIpsecAggregateMember(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "tunnel_name", d)
+	dynamic_sort_subtable_natural(result, "tunnel_name", d)
 	return result
 }
 

--- a/fortios/resource_system_linkmonitor.go
+++ b/fortios/resource_system_linkmonitor.go
@@ -442,7 +442,7 @@ func flattenSystemLinkMonitorServer(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "address", d)
+	dynamic_sort_subtable_natural(result, "address", d)
 	return result
 }
 
@@ -496,7 +496,7 @@ func flattenSystemLinkMonitorRoute(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "subnet", d)
+	dynamic_sort_subtable_natural(result, "subnet", d)
 	return result
 }
 
@@ -646,7 +646,7 @@ func flattenSystemLinkMonitorServerList(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_mobiletunnel.go
+++ b/fortios/resource_system_mobiletunnel.go
@@ -355,7 +355,7 @@ func flattenSystemMobileTunnelNetwork(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_nat64.go
+++ b/fortios/resource_system_nat64.go
@@ -229,7 +229,7 @@ func flattenSystemNat64SecondaryPrefix(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_ndproxy.go
+++ b/fortios/resource_system_ndproxy.go
@@ -186,7 +186,7 @@ func flattenSystemNdProxyMember(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_system_ntp.go
+++ b/fortios/resource_system_ntp.go
@@ -338,7 +338,7 @@ func flattenSystemNtpNtpserver(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -432,7 +432,7 @@ func flattenSystemNtpInterface(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_system_objecttagging.go
+++ b/fortios/resource_system_objecttagging.go
@@ -266,7 +266,7 @@ func flattenSystemObjectTaggingTags(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_ptp.go
+++ b/fortios/resource_system_ptp.go
@@ -254,7 +254,7 @@ func flattenSystemPtpServerInterface(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_replacemsggroup.go
+++ b/fortios/resource_system_replacemsggroup.go
@@ -792,7 +792,7 @@ func flattenSystemReplacemsgGroupMail(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -860,7 +860,7 @@ func flattenSystemReplacemsgGroupHttp(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -928,7 +928,7 @@ func flattenSystemReplacemsgGroupWebproxy(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -996,7 +996,7 @@ func flattenSystemReplacemsgGroupFtp(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1064,7 +1064,7 @@ func flattenSystemReplacemsgGroupNntp(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1132,7 +1132,7 @@ func flattenSystemReplacemsgGroupFortiguardWf(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1200,7 +1200,7 @@ func flattenSystemReplacemsgGroupSpam(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1268,7 +1268,7 @@ func flattenSystemReplacemsgGroupAlertmail(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1336,7 +1336,7 @@ func flattenSystemReplacemsgGroupAdmin(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1404,7 +1404,7 @@ func flattenSystemReplacemsgGroupAuth(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1472,7 +1472,7 @@ func flattenSystemReplacemsgGroupSslvpn(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1540,7 +1540,7 @@ func flattenSystemReplacemsgGroupEc(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1608,7 +1608,7 @@ func flattenSystemReplacemsgGroupDeviceDetectionPortal(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1676,7 +1676,7 @@ func flattenSystemReplacemsgGroupNacQuar(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1744,7 +1744,7 @@ func flattenSystemReplacemsgGroupTrafficQuota(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1812,7 +1812,7 @@ func flattenSystemReplacemsgGroupUtm(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1880,7 +1880,7 @@ func flattenSystemReplacemsgGroupCustomMessage(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -1948,7 +1948,7 @@ func flattenSystemReplacemsgGroupIcap(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 
@@ -2016,7 +2016,7 @@ func flattenSystemReplacemsgGroupAutomation(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "msg_type", d)
+	dynamic_sort_subtable_natural(result, "msg_type", d)
 	return result
 }
 

--- a/fortios/resource_system_saml.go
+++ b/fortios/resource_system_saml.go
@@ -490,7 +490,7 @@ func flattenSystemSamlServiceProviders(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_sdnconnector.go
+++ b/fortios/resource_system_sdnconnector.go
@@ -665,7 +665,7 @@ func flattenSystemSdnConnectorServerList(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -749,7 +749,7 @@ func flattenSystemSdnConnectorExternalAccountList(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "role_arn", d)
+	dynamic_sort_subtable_natural(result, "role_arn", d)
 	return result
 }
 
@@ -862,7 +862,7 @@ func flattenSystemSdnConnectorNic(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -975,7 +975,7 @@ func flattenSystemSdnConnectorRouteTable(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1092,7 +1092,7 @@ func flattenSystemSdnConnectorExternalIp(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1130,7 +1130,7 @@ func flattenSystemSdnConnectorRoute(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1174,7 +1174,7 @@ func flattenSystemSdnConnectorGcpProjectList(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1255,7 +1255,7 @@ func flattenSystemSdnConnectorForwardingRule(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "rule_name", d)
+	dynamic_sort_subtable_natural(result, "rule_name", d)
 	return result
 }
 

--- a/fortios/resource_system_sdwan.go
+++ b/fortios/resource_system_sdwan.go
@@ -1254,7 +1254,7 @@ func flattenSystemSdwanFailAlertInterfaces(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1298,7 +1298,7 @@ func flattenSystemSdwanZone(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1430,7 +1430,7 @@ func flattenSystemSdwanMembers(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "seq_num", d)
+	dynamic_sort_subtable_natural(result, "seq_num", d)
 	return result
 }
 
@@ -1760,7 +1760,7 @@ func flattenSystemSdwanHealthCheck(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2086,7 +2086,7 @@ func flattenSystemSdwanNeighbor(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -2462,7 +2462,7 @@ func flattenSystemSdwanService(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -3343,7 +3343,7 @@ func flattenSystemSdwanDuplication(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_sessionttl.go
+++ b/fortios/resource_system_sessionttl.go
@@ -233,7 +233,7 @@ func flattenSystemSessionTtlPort(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_settings.go
+++ b/fortios/resource_system_settings.go
@@ -986,7 +986,7 @@ func flattenSystemSettingsGuiDefaultPolicyColumns(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_speedtestschedule.go
+++ b/fortios/resource_system_speedtestschedule.go
@@ -287,7 +287,7 @@ func flattenSystemSpeedTestScheduleSchedules(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_speedtestserver.go
+++ b/fortios/resource_system_speedtestserver.go
@@ -279,7 +279,7 @@ func flattenSystemSpeedTestServerHost(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_ssoadmin.go
+++ b/fortios/resource_system_ssoadmin.go
@@ -229,7 +229,7 @@ func flattenSystemSsoAdminVdom(v interface{}, d *schema.ResourceData, pre string
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_ssoforticloudadmin.go
+++ b/fortios/resource_system_ssoforticloudadmin.go
@@ -220,7 +220,7 @@ func flattenSystemSsoForticloudAdminVdom(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_switchinterface.go
+++ b/fortios/resource_system_switchinterface.go
@@ -279,7 +279,7 @@ func flattenSystemSwitchInterfaceSpanSourcePort(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 
@@ -317,7 +317,7 @@ func flattenSystemSwitchInterfaceMember(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_system_vdomdns.go
+++ b/fortios/resource_system_vdomdns.go
@@ -273,7 +273,7 @@ func flattenSystemVdomDnsServerHostname(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "hostname", d)
+	dynamic_sort_subtable_natural(result, "hostname", d)
 	return result
 }
 

--- a/fortios/resource_system_vdomexception.go
+++ b/fortios/resource_system_vdomexception.go
@@ -246,7 +246,7 @@ func flattenSystemVdomExceptionVdom(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_virtualswitch.go
+++ b/fortios/resource_system_virtualswitch.go
@@ -273,7 +273,7 @@ func flattenSystemVirtualSwitchPort(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_system_virtualwanlink.go
+++ b/fortios/resource_system_virtualwanlink.go
@@ -1042,7 +1042,7 @@ func flattenSystemVirtualWanLinkFailAlertInterfaces(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1080,7 +1080,7 @@ func flattenSystemVirtualWanLinkZone(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1196,7 +1196,7 @@ func flattenSystemVirtualWanLinkMembers(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "seq_num", d)
+	dynamic_sort_subtable_natural(result, "seq_num", d)
 	return result
 }
 
@@ -1482,7 +1482,7 @@ func flattenSystemVirtualWanLinkHealthCheck(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1778,7 +1778,7 @@ func flattenSystemVirtualWanLinkNeighbor(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -2162,7 +2162,7 @@ func flattenSystemVirtualWanLinkService(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_system_virtualwirepair.go
+++ b/fortios/resource_system_virtualwirepair.go
@@ -230,7 +230,7 @@ func flattenSystemVirtualWirePairMember(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_system_vxlan.go
+++ b/fortios/resource_system_vxlan.go
@@ -272,7 +272,7 @@ func flattenSystemVxlanRemoteIp(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip", d)
+	dynamic_sort_subtable_natural(result, "ip", d)
 	return result
 }
 
@@ -310,7 +310,7 @@ func flattenSystemVxlanRemoteIp6(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ip6", d)
+	dynamic_sort_subtable_natural(result, "ip6", d)
 	return result
 }
 

--- a/fortios/resource_system_zone.go
+++ b/fortios/resource_system_zone.go
@@ -277,7 +277,7 @@ func flattenSystemZoneTagging(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -364,7 +364,7 @@ func flattenSystemZoneInterface(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "interface_name", d)
+	dynamic_sort_subtable_natural(result, "interface_name", d)
 	return result
 }
 

--- a/fortios/resource_systemdhcp6_server.go
+++ b/fortios/resource_systemdhcp6_server.go
@@ -447,7 +447,7 @@ func flattenSystemDhcp6ServerPrefixRange(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -509,7 +509,7 @@ func flattenSystemDhcp6ServerIpRange(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_systemdhcp_server.go
+++ b/fortios/resource_systemdhcp_server.go
@@ -704,7 +704,7 @@ func flattenSystemDhcpServerIpRange(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -758,7 +758,7 @@ func flattenSystemDhcpServerTftpServer(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "tftp_server", d)
+	dynamic_sort_subtable_natural(result, "tftp_server", d)
 	return result
 }
 
@@ -824,7 +824,7 @@ func flattenSystemDhcpServerOptions(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -942,7 +942,7 @@ func flattenSystemDhcpServerVciString(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "vci_string", d)
+	dynamic_sort_subtable_natural(result, "vci_string", d)
 	return result
 }
 
@@ -992,7 +992,7 @@ func flattenSystemDhcpServerExcludeRange(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1092,7 +1092,7 @@ func flattenSystemDhcpServerReservedAddress(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_systemsnmp_community.go
+++ b/fortios/resource_systemsnmp_community.go
@@ -373,7 +373,7 @@ func flattenSystemSnmpCommunityHosts(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -451,7 +451,7 @@ func flattenSystemSnmpCommunityHosts6(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_user_device.go
+++ b/fortios/resource_user_device.go
@@ -309,7 +309,7 @@ func flattenUserDeviceTagging(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_user_deviceaccesslist.go
+++ b/fortios/resource_user_deviceaccesslist.go
@@ -250,7 +250,7 @@ func flattenUserDeviceAccessListDeviceList(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_user_devicegroup.go
+++ b/fortios/resource_user_devicegroup.go
@@ -258,7 +258,7 @@ func flattenUserDeviceGroupMember(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -308,7 +308,7 @@ func flattenUserDeviceGroupTagging(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_user_domaincontroller.go
+++ b/fortios/resource_user_domaincontroller.go
@@ -418,7 +418,7 @@ func flattenUserDomainControllerExtraServer(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_user_exchange.go
+++ b/fortios/resource_user_exchange.go
@@ -323,7 +323,7 @@ func flattenUserExchangeKdcIp(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "ipv4", d)
+	dynamic_sort_subtable_natural(result, "ipv4", d)
 	return result
 }
 

--- a/fortios/resource_user_fssopolling.go
+++ b/fortios/resource_user_fssopolling.go
@@ -315,7 +315,7 @@ func flattenUserFssoPollingAdgrp(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_user_group.go
+++ b/fortios/resource_user_group.go
@@ -445,7 +445,7 @@ func flattenUserGroupMember(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -495,7 +495,7 @@ func flattenUserGroupMatch(v interface{}, d *schema.ResourceData, pre string, sv
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -651,7 +651,7 @@ func flattenUserGroupGuest(v interface{}, d *schema.ResourceData, pre string, sv
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "user_id", d)
+	dynamic_sort_subtable_natural(result, "user_id", d)
 	return result
 }
 

--- a/fortios/resource_user_nacpolicy.go
+++ b/fortios/resource_user_nacpolicy.go
@@ -420,7 +420,7 @@ func flattenUserNacPolicySwitchGroup(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -458,7 +458,7 @@ func flattenUserNacPolicySwitchScope(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "switch_id", d)
+	dynamic_sort_subtable_natural(result, "switch_id", d)
 	return result
 }
 

--- a/fortios/resource_user_peergrp.go
+++ b/fortios/resource_user_peergrp.go
@@ -220,7 +220,7 @@ func flattenUserPeergrpMember(v interface{}, d *schema.ResourceData, pre string,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_user_quarantine.go
+++ b/fortios/resource_user_quarantine.go
@@ -259,7 +259,7 @@ func flattenUserQuarantineTargets(v interface{}, d *schema.ResourceData, pre str
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "entry", d)
+	dynamic_sort_subtable_natural(result, "entry", d)
 	return result
 }
 

--- a/fortios/resource_user_radius.go
+++ b/fortios/resource_user_radius.go
@@ -561,7 +561,7 @@ func flattenUserRadiusClass(v interface{}, d *schema.ResourceData, pre string, s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -733,7 +733,7 @@ func flattenUserRadiusAccountingServer(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_user_securityexemptlist.go
+++ b/fortios/resource_user_securityexemptlist.go
@@ -309,7 +309,7 @@ func flattenUserSecurityExemptListRule(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_user_setting.go
+++ b/fortios/resource_user_setting.go
@@ -379,7 +379,7 @@ func flattenUserSettingAuthPorts(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_videofilter_youtubechannelfilter.go
+++ b/fortios/resource_videofilter_youtubechannelfilter.go
@@ -285,7 +285,7 @@ func flattenVideofilterYoutubeChannelFilterEntries(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_vpn_ocvpn.go
+++ b/fortios/resource_vpn_ocvpn.go
@@ -387,7 +387,7 @@ func flattenVpnOcvpnWanInterface(v interface{}, d *schema.ResourceData, pre stri
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -502,7 +502,7 @@ func flattenVpnOcvpnOverlays(v interface{}, d *schema.ResourceData, pre string, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_vpnipsec_concentrator.go
+++ b/fortios/resource_vpnipsec_concentrator.go
@@ -239,7 +239,7 @@ func flattenVpnIpsecConcentratorMember(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_vpnipsec_fec.go
+++ b/fortios/resource_vpnipsec_fec.go
@@ -300,7 +300,7 @@ func flattenVpnIpsecFecMappings(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "seqno", d)
+	dynamic_sort_subtable_natural(result, "seqno", d)
 	return result
 }
 

--- a/fortios/resource_vpnipsec_phase1.go
+++ b/fortios/resource_vpnipsec_phase1.go
@@ -908,7 +908,7 @@ func flattenVpnIpsecPhase1Certificate(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1046,7 +1046,7 @@ func flattenVpnIpsecPhase1Ipv4ExcludeRange(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1140,7 +1140,7 @@ func flattenVpnIpsecPhase1Ipv6ExcludeRange(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1234,7 +1234,7 @@ func flattenVpnIpsecPhase1BackupGateway(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "address", d)
+	dynamic_sort_subtable_natural(result, "address", d)
 	return result
 }
 

--- a/fortios/resource_vpnipsec_phase1interface.go
+++ b/fortios/resource_vpnipsec_phase1interface.go
@@ -1079,7 +1079,7 @@ func flattenVpnIpsecPhase1InterfaceCertificate(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1277,7 +1277,7 @@ func flattenVpnIpsecPhase1InterfaceIpv4ExcludeRange(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1371,7 +1371,7 @@ func flattenVpnIpsecPhase1InterfaceIpv6ExcludeRange(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -1465,7 +1465,7 @@ func flattenVpnIpsecPhase1InterfaceBackupGateway(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "address", d)
+	dynamic_sort_subtable_natural(result, "address", d)
 	return result
 }
 

--- a/fortios/resource_vpnssl_settings.go
+++ b/fortios/resource_vpnssl_settings.go
@@ -796,7 +796,7 @@ func flattenVpnSslSettingsTunnelIpPools(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -834,7 +834,7 @@ func flattenVpnSslSettingsTunnelIpv6Pools(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -948,7 +948,7 @@ func flattenVpnSslSettingsSourceInterface(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -986,7 +986,7 @@ func flattenVpnSslSettingsSourceAddress(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1028,7 +1028,7 @@ func flattenVpnSslSettingsSourceAddress6(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1152,7 +1152,7 @@ func flattenVpnSslSettingsAuthenticationRule(v interface{}, d *schema.ResourceDa
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_vpnsslweb_hostchecksoftware.go
+++ b/fortios/resource_vpnsslweb_hostchecksoftware.go
@@ -323,7 +323,7 @@ func flattenVpnSslWebHostCheckSoftwareCheckItemList(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_vpnsslweb_portal.go
+++ b/fortios/resource_vpnsslweb_portal.go
@@ -889,7 +889,7 @@ func flattenVpnSslWebPortalIpPools(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -943,7 +943,7 @@ func flattenVpnSslWebPortalSplitTunnelingRoutingAddress(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1005,7 +1005,7 @@ func flattenVpnSslWebPortalIpv6Pools(v interface{}, d *schema.ResourceData, pre 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1059,7 +1059,7 @@ func flattenVpnSslWebPortalIpv6SplitTunnelingRoutingAddress(v interface{}, d *sc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1139,7 +1139,7 @@ func flattenVpnSslWebPortalBookmarkGroup(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1637,7 +1637,7 @@ func flattenVpnSslWebPortalHostCheckPolicy(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1699,7 +1699,7 @@ func flattenVpnSslWebPortalMacAddrCheckRule(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1800,7 +1800,7 @@ func flattenVpnSslWebPortalOsCheckList(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1912,7 +1912,7 @@ func flattenVpnSslWebPortalSplitDns(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_vpnsslweb_userbookmark.go
+++ b/fortios/resource_vpnsslweb_userbookmark.go
@@ -589,7 +589,7 @@ func flattenVpnSslWebUserBookmarkBookmarks(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_vpnsslweb_usergroupbookmark.go
+++ b/fortios/resource_vpnsslweb_usergroupbookmark.go
@@ -579,7 +579,7 @@ func flattenVpnSslWebUserGroupBookmarkBookmarks(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_waf_profile.go
+++ b/fortios/resource_waf_profile.go
@@ -2752,7 +2752,7 @@ func flattenWafProfileUrlAccess(v interface{}, d *schema.ResourceData, pre strin
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wanopt_cacheservice.go
+++ b/fortios/resource_wanopt_cacheservice.go
@@ -298,7 +298,7 @@ func flattenWanoptCacheServiceDstPeer(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "device_id", d)
+	dynamic_sort_subtable_natural(result, "device_id", d)
 	return result
 }
 
@@ -376,7 +376,7 @@ func flattenWanoptCacheServiceSrcPeer(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "device_id", d)
+	dynamic_sort_subtable_natural(result, "device_id", d)
 	return result
 }
 

--- a/fortios/resource_wanopt_contentdeliverynetworkrule.go
+++ b/fortios/resource_wanopt_contentdeliverynetworkrule.go
@@ -408,7 +408,7 @@ func flattenWanoptContentDeliveryNetworkRuleHostDomainNameSuffix(v interface{}, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -500,7 +500,7 @@ func flattenWanoptContentDeliveryNetworkRuleRules(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_webfilter_content.go
+++ b/fortios/resource_webfilter_content.go
@@ -291,7 +291,7 @@ func flattenWebfilterContentEntries(v interface{}, d *schema.ResourceData, pre s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_webfilter_contentheader.go
+++ b/fortios/resource_webfilter_contentheader.go
@@ -258,7 +258,7 @@ func flattenWebfilterContentHeaderEntries(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "pattern", d)
+	dynamic_sort_subtable_natural(result, "pattern", d)
 	return result
 }
 

--- a/fortios/resource_webfilter_profile.go
+++ b/fortios/resource_webfilter_profile.go
@@ -1447,7 +1447,7 @@ func flattenWebfilterProfileYoutubeChannelFilter(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2078,7 +2078,7 @@ func flattenWebfilterProfileWispServers(v interface{}, d *schema.ResourceData, p
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_webfilter_urlfilter.go
+++ b/fortios/resource_webfilter_urlfilter.go
@@ -355,7 +355,7 @@ func flattenWebfilterUrlfilterEntries(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_webproxy_explicit.go
+++ b/fortios/resource_webproxy_explicit.go
@@ -510,7 +510,7 @@ func flattenWebProxyExplicitPacPolicy(v interface{}, d *schema.ResourceData, pre
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "policyid", d)
+	dynamic_sort_subtable_natural(result, "policyid", d)
 	return result
 }
 

--- a/fortios/resource_webproxy_forwardservergroup.go
+++ b/fortios/resource_webproxy_forwardservergroup.go
@@ -259,7 +259,7 @@ func flattenWebProxyForwardServerGroupServerList(v interface{}, d *schema.Resour
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_webproxy_global.go
+++ b/fortios/resource_webproxy_global.go
@@ -352,7 +352,7 @@ func flattenWebProxyGlobalLearnClientIpSrcaddr(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -390,7 +390,7 @@ func flattenWebProxyGlobalLearnClientIpSrcaddr6(v interface{}, d *schema.Resourc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_webproxy_profile.go
+++ b/fortios/resource_webproxy_profile.go
@@ -417,7 +417,7 @@ func flattenWebProxyProfileHeaders(v interface{}, d *schema.ResourceData, pre st
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_accesscontrollist.go
+++ b/fortios/resource_wirelesscontroller_accesscontrollist.go
@@ -364,7 +364,7 @@ func flattenWirelessControllerAccessControlListLayer3Ipv4Rules(v interface{}, d 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "rule_id", d)
+	dynamic_sort_subtable_natural(result, "rule_id", d)
 	return result
 }
 
@@ -472,7 +472,7 @@ func flattenWirelessControllerAccessControlListLayer3Ipv6Rules(v interface{}, d 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "rule_id", d)
+	dynamic_sort_subtable_natural(result, "rule_id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_addrgrp.go
+++ b/fortios/resource_wirelesscontroller_addrgrp.go
@@ -229,7 +229,7 @@ func flattenWirelessControllerAddrgrpAddresses(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_apcfgprofile.go
+++ b/fortios/resource_wirelesscontroller_apcfgprofile.go
@@ -327,7 +327,7 @@ func flattenWirelessControllerApcfgProfileCommandList(v interface{}, d *schema.R
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_arrpprofile.go
+++ b/fortios/resource_wirelesscontroller_arrpprofile.go
@@ -416,7 +416,7 @@ func flattenWirelessControllerArrpProfileDarrpOptimizeSchedules(v interface{}, d
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_bonjourprofile.go
+++ b/fortios/resource_wirelesscontroller_bonjourprofile.go
@@ -277,7 +277,7 @@ func flattenWirelessControllerBonjourProfilePolicyList(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "policy_id", d)
+	dynamic_sort_subtable_natural(result, "policy_id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_intercontroller.go
+++ b/fortios/resource_wirelesscontroller_intercontroller.go
@@ -258,7 +258,7 @@ func flattenWirelessControllerInterControllerInterControllerPeer(v interface{}, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_mpskprofile.go
+++ b/fortios/resource_wirelesscontroller_mpskprofile.go
@@ -314,7 +314,7 @@ func flattenWirelessControllerMpskProfileMpskGroup(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_qosprofile.go
+++ b/fortios/resource_wirelesscontroller_qosprofile.go
@@ -415,7 +415,7 @@ func flattenWirelessControllerQosProfileDscpWmmVo(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -453,7 +453,7 @@ func flattenWirelessControllerQosProfileDscpWmmVi(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -491,7 +491,7 @@ func flattenWirelessControllerQosProfileDscpWmmBe(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -529,7 +529,7 @@ func flattenWirelessControllerQosProfileDscpWmmBk(v interface{}, d *schema.Resou
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_setting.go
+++ b/fortios/resource_wirelesscontroller_setting.go
@@ -307,7 +307,7 @@ func flattenWirelessControllerSettingOffendingSsid(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -373,7 +373,7 @@ func flattenWirelessControllerSettingDarrpOptimizeSchedules(v interface{}, d *sc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_snmp.go
+++ b/fortios/resource_wirelesscontroller_snmp.go
@@ -368,7 +368,7 @@ func flattenWirelessControllerSnmpCommunity(v interface{}, d *schema.ResourceDat
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -539,7 +539,7 @@ func flattenWirelessControllerSnmpUser(v interface{}, d *schema.ResourceData, pr
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_timers.go
+++ b/fortios/resource_wirelesscontroller_timers.go
@@ -294,7 +294,7 @@ func flattenWirelessControllerTimersDarrpTime(v interface{}, d *schema.ResourceD
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "time", d)
+	dynamic_sort_subtable_natural(result, "time", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_vap.go
+++ b/fortios/resource_wirelesscontroller_vap.go
@@ -1388,7 +1388,7 @@ func flattenWirelessControllerVapRadiusMacAuthUsergroups(v interface{}, d *schem
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1494,7 +1494,7 @@ func flattenWirelessControllerVapUsergroup(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1593,7 +1593,7 @@ func flattenWirelessControllerVapSelectedUsergroups(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1723,7 +1723,7 @@ func flattenWirelessControllerVapMpskKey(v interface{}, d *schema.ResourceData, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "key_name", d)
+	dynamic_sort_subtable_natural(result, "key_name", d)
 	return result
 }
 
@@ -1928,7 +1928,7 @@ func flattenWirelessControllerVapVlanName(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -1980,7 +1980,7 @@ func flattenWirelessControllerVapVlanPool(v interface{}, d *schema.ResourceData,
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2178,7 +2178,7 @@ func flattenWirelessControllerVapMacFilterList(v interface{}, d *schema.Resource
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_vapgroup.go
+++ b/fortios/resource_wirelesscontroller_vapgroup.go
@@ -228,7 +228,7 @@ func flattenWirelessControllerVapGroupVaps(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_widsprofile.go
+++ b/fortios/resource_wirelesscontroller_widsprofile.go
@@ -523,7 +523,7 @@ func flattenWirelessControllerWidsProfileApBgscanDisableSchedules(v interface{},
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_wtp.go
+++ b/fortios/resource_wirelesscontroller_wtp.go
@@ -1129,7 +1129,7 @@ func flattenWirelessControllerWtpSplitTunnelingAcl(v interface{}, d *schema.Reso
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_wtpgroup.go
+++ b/fortios/resource_wirelesscontroller_wtpgroup.go
@@ -229,7 +229,7 @@ func flattenWirelessControllerWtpGroupWtps(v interface{}, d *schema.ResourceData
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "wtp_id", d)
+	dynamic_sort_subtable_natural(result, "wtp_id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontroller_wtpprofile.go
+++ b/fortios/resource_wirelesscontroller_wtpprofile.go
@@ -2684,7 +2684,7 @@ func flattenWirelessControllerWtpProfileLedSchedules(v interface{}, d *schema.Re
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 
@@ -2752,7 +2752,7 @@ func flattenWirelessControllerWtpProfileDenyMacList(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 
@@ -2824,7 +2824,7 @@ func flattenWirelessControllerWtpProfileSplitTunnelingAcl(v interface{}, d *sche
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_anqp3gppcellular.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_anqp3gppcellular.go
@@ -244,7 +244,7 @@ func flattenWirelessControllerHotspot20Anqp3GppCellularMccMncList(v interface{},
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "id", d)
+	dynamic_sort_subtable_natural(result, "id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_anqpnairealm.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_anqpnairealm.go
@@ -292,7 +292,7 @@ func flattenWirelessControllerHotspot20AnqpNaiRealmNaiList(v interface{}, d *sch
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_anqproamingconsortium.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_anqproamingconsortium.go
@@ -244,7 +244,7 @@ func flattenWirelessControllerHotspot20AnqpRoamingConsortiumOiList(v interface{}
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_anqpvenuename.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_anqpvenuename.go
@@ -244,7 +244,7 @@ func flattenWirelessControllerHotspot20AnqpVenueNameValueList(v interface{}, d *
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_anqpvenueurl.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_anqpvenueurl.go
@@ -244,7 +244,7 @@ func flattenWirelessControllerHotspot20AnqpVenueUrlValueList(v interface{}, d *s
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_h2qpadviceofcharge.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_h2qpadviceofcharge.go
@@ -293,7 +293,7 @@ func flattenWirelessControllerHotspot20H2QpAdviceOfChargeAocList(v interface{}, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_h2qpoperatorname.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_h2qpoperatorname.go
@@ -244,7 +244,7 @@ func flattenWirelessControllerHotspot20H2QpOperatorNameValueList(v interface{}, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_h2qposuprovider.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_h2qposuprovider.go
@@ -292,7 +292,7 @@ func flattenWirelessControllerHotspot20H2QpOsuProviderFriendlyName(v interface{}
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 
@@ -362,7 +362,7 @@ func flattenWirelessControllerHotspot20H2QpOsuProviderServiceDescription(v inter
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "service_id", d)
+	dynamic_sort_subtable_natural(result, "service_id", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_h2qposuprovidernai.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_h2qposuprovidernai.go
@@ -232,7 +232,7 @@ func flattenWirelessControllerHotspot20H2QpOsuProviderNaiNaiList(v interface{}, 
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_hsprofile.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_hsprofile.go
@@ -542,7 +542,7 @@ func flattenWirelessControllerHotspot20HsProfileOsuProvider(v interface{}, d *sc
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_icon.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_icon.go
@@ -279,7 +279,7 @@ func flattenWirelessControllerHotspot20IconIconList(v interface{}, d *schema.Res
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "name", d)
+	dynamic_sort_subtable_natural(result, "name", d)
 	return result
 }
 

--- a/fortios/resource_wirelesscontrollerhotspot20_qosmap.go
+++ b/fortios/resource_wirelesscontrollerhotspot20_qosmap.go
@@ -276,7 +276,7 @@ func flattenWirelessControllerHotspot20QosMapDscpExcept(v interface{}, d *schema
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 
@@ -340,7 +340,7 @@ func flattenWirelessControllerHotspot20QosMapDscpRange(v interface{}, d *schema.
 		con += 1
 	}
 
-	dynamic_sort_subtable(result, "index", d)
+	dynamic_sort_subtable_natural(result, "index", d)
 	return result
 }
 


### PR DESCRIPTION
Closes #217 

Renaming dynamic_sort_subtable to dynamic_sort_subtable_natural.
Creating dynamic_sort_subtable which does not perform additional natural sort. 
Changes servicegroups to use original alpha numeric method
Changes firewall policy src/dst address objects to also be alpha numeric sort