### PR TITLE
Allow proxy usage

### DIFF
--- a/fortios/client.go
+++ b/fortios/client.go
@@ -204,6 +204,7 @@ func createFortiOSClient(fClient *FortiClient, c *Config) error {
 	}
 
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: config,
 	}
 
@@ -278,6 +279,7 @@ func createFortiManagerClient(fClient *FortiClient, c *Config) error {
 	}
 
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: config,
 	}
 


### PR DESCRIPTION
With this change it is possible to use HTTPS_PROXY as transport for connecting to the api

this fixes https://github.com/fortinetdev/terraform-provider-fortios/issues/229