### PR TITLE
docs: fortios_webfilter_profile.html.markdown

### DIFF
--- a/website/docs/r/fortios_webfilter_profile.html.markdown
+++ b/website/docs/r/fortios_webfilter_profile.html.markdown
@@ -215,7 +215,7 @@ The `ftgd_wf` block supports:
 The `filters` block supports:
 
 * `id` - ID number.
-* `category` - Categories and groups the filter examines.
+* `category` - [Categories](https://docs.fortinet.com/document/fortigate/7.4.0/fortios-log-message-reference/755423/fortiguard-web-filter-categories) and groups the filter examines.
 * `action` - Action to take for matches. Valid values: `block`, `authenticate`, `monitor`, `warning`.
 * `warn_duration` - Duration of warnings.
 * `auth_usr_grp` - Groups with permission to authenticate. The structure of `auth_usr_grp` block is documented below.


### PR DESCRIPTION
not sure what the guidelines are for the docs but I think its useful to add more context to make it easier to use 
as an example the categorie for web filter profile is a number id which you could look up in this nice page at docs.fortinet.com


please let me know what you think about these types of ease of use improvements