### PR TITLE
fixed example to correct working value

### DIFF
--- a/website/docs/d/fortios_system_interfacelist.html.markdown
+++ b/website/docs/d/fortios_system_interfacelist.html.markdown
@@ -17,7 +17,7 @@ data "fortios_system_interfacelist" sample1 {
 }
 
 output output1 {
-  value = data.fortios_system_interfacelist.sample2.namelist
+  value = data.fortios_system_interfacelist.sample1.namelist
 }
 ```
 


### PR DESCRIPTION
A small documentation update to the `website/docs/d/fortios_system_interfacelist.html.markdown` file. The change updates the `output1` value to reference `sample1` instead of `sample2` for consistency with the data block definition.

![Hello there](https://media.giphy.com/media/vFKqnCdLPNOKc/giphy.gif)