### PR TITLE
(fix): perpetual drift in `fortios_system_dnsdatabase` `interface_select_method`

### DIFF
--- a/fortios/resource_system_dnsdatabase.go
+++ b/fortios/resource_system_dnsdatabase.go
@@ -688,9 +688,16 @@ func refreshObjectSystemDnsDatabase(d *schema.ResourceData, o map[string]interfa
 		}
 	}
 
-	if err = d.Set("interface_select_method", flattenSystemDnsDatabaseInterfaceSelectMethod(o["interface-select-method"], d, "interface_select_method", sv)); err != nil {
-		if !fortiAPIPatch(o["interface-select-method"]) {
+	if v, ok := o["interface-select-method"]; ok && v != nil {
+		if err = d.Set("interface_select_method", flattenSystemDnsDatabaseInterfaceSelectMethod(v, d, "interface_select_method", sv)); err != nil {
 			return fmt.Errorf("Error reading interface_select_method: %v", err)
+		}
+	} else {
+		// API didn't return interface-select-method, preserve config value if set
+		if configValue, configOk := d.GetOk("interface_select_method"); configOk {
+			if err = d.Set("interface_select_method", configValue); err != nil {
+				return fmt.Errorf("Error setting interface_select_method from config: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
When `interface_select_method` is set to its default value `("auto")`, the FortiOS API omits this field from GET responses. This caused Terraform to continuously detect drift and attempt to add the field on every apply.

Fixes persistent plan changes showing:
  + interface_select_method = "auto"